### PR TITLE
Refactor post parser

### DIFF
--- a/dapp/package.json
+++ b/dapp/package.json
@@ -45,6 +45,7 @@
     "markdown-to-jsx": "^7.1.3",
     "node-sass": "^6.0.1",
     "nprogress": "^0.2.0",
+    "parjs": "^0.12.7",
     "pubsub-js": "^1.9.3",
     "query-string": "^7.0.1",
     "react": "^17.0.2",

--- a/dapp/src/components/post/Post.tsx
+++ b/dapp/src/components/post/Post.tsx
@@ -13,23 +13,6 @@ import PostHeader from "./PostHeader";
 import sanitize from "sanitize-html";
 import useFavorites from "hooks/useFavorites";
 import { isArray } from "lodash";
-import parseComment, { ParserResult, PostReferenceValue } from "dchan/postparse";
-
-function getPostRefs(vals: ParserResult[]): PostReferenceValue[] {
-  let ret: PostReferenceValue[] = [];
-  for (let val of vals) {
-    switch(val.type) {
-      case "postref":
-        ret.push(val);
-        break;
-      case "textquote":
-      case "spoiler":
-        ret.push(...getPostRefs(val.value));
-        break;
-    }
-  }
-  return ret;
-}
 
 export default function Post({
   children,
@@ -49,7 +32,7 @@ export default function Post({
   const [isFocused, setIsFocused] = useState<boolean>(false);
   const [backlinks, setBacklinks] = useState<object>({});
   const postRef = useRef<HTMLInputElement>(null);
-  const { publish, subscribe, unsubscribe } = usePubSub();
+  const { subscribe, unsubscribe } = usePubSub();
 
   let {
     id,
@@ -125,20 +108,6 @@ export default function Post({
       };
     }
   });
-
-  useEffect(() => {
-    let backlinks = getPostRefs(parseComment(post.comment));
-    for (let link of backlinks) {
-      const backlink = {
-        from: post,
-        to: {
-          userId: link.id,
-          n: link.n,
-        }
-      };
-      publish("POST_BACKLINK", backlink);
-    }
-  }, [post, publish]);
 
   const ipfsUrl = !!image ? `https://ipfs.io/ipfs/${image.ipfsHash}` : "";
   const isOp = id === thread?.id;

--- a/dapp/src/components/post/PostBody.tsx
+++ b/dapp/src/components/post/PostBody.tsx
@@ -1,8 +1,9 @@
-import { Post, Thread } from 'dchan';
+import { Post, shortenAddress, Thread } from 'dchan';
 import { Router } from 'router';
 import parseComment, { ParserResult, PostReferenceValue } from 'dchan/postparse';
 import { ReactElement, useCallback } from 'react';
 import usePubSub from 'hooks/usePubSub';
+import useWeb3 from 'hooks/useWeb3';
 
 function TextQuote({children, post, thread}: {children: ParserResult[], post: Post, thread?: Thread}) {
   return (
@@ -48,6 +49,12 @@ function PostReference({post, thread, value}: {post: Post, thread?: Thread, valu
 
   const baseUrl = `${post.board ? Router.board(post.board) : ""}/${post.thread ? `${post.from.id}/${post.thread.n}/` : ""}`;
 
+  const { accounts } = useWeb3();
+
+  const isYou = accounts && accounts[0] && refPost
+    ? accounts[0] === refPost.from.address
+    : false;
+
   return (
     <a
       className="text-blue-600 visited:text-purple-600 hover:text-blue-500"
@@ -55,7 +62,7 @@ function PostReference({post, thread, value}: {post: Post, thread?: Thread, valu
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
     >
-      &gt;&gt;{postLink}
+      &gt;&gt;{postLink}{isYou ? " (You)" : ""}
     </a>
   );
 }

--- a/dapp/src/components/post/PostBody.tsx
+++ b/dapp/src/components/post/PostBody.tsx
@@ -1,7 +1,7 @@
-import { Post, shortenAddress, Thread } from 'dchan';
+import { Post, Thread } from 'dchan';
 import { Router } from 'router';
 import parseComment, { ParserResult, PostReferenceValue } from 'dchan/postparse';
-import { ReactElement, useCallback } from 'react';
+import { ReactElement, useCallback, useEffect } from 'react';
 import usePubSub from 'hooks/usePubSub';
 import useWeb3 from 'hooks/useWeb3';
 
@@ -29,6 +29,18 @@ function PostReference({post, thread, value}: {post: Post, thread?: Thread, valu
   const postLink = `${value.id}/${value.n}`;
 
   const refPost = thread?.replies?.find(p => `${p.from.id}/${p.n}` === postLink);
+
+  useEffect(() => {
+    const backlink = {
+      from: post,
+      to: {
+        userId: value.id,
+        n: value.n,
+      }
+    };
+    //console.log(`Post ${post.n} sending backlink to ${value.n}`);
+    publish("POST_BACKLINK", backlink);
+  }, [post, value, publish]);
 
   const onMouseEnter = useCallback(
     () => {
@@ -94,14 +106,14 @@ function IPFSImage({hash}: {hash: string}) {
       <summary>
         <a
           className="text-blue-600 visited:text-purple-600 hover:text-blue-500"
-          href="//ipfs.io/ipfs/$1"
+          href={`//ipfs.io/ipfs/${hash}`}
           target="_blank"
           rel="noreferrer"
         >
           {hash}
         </a>
       </summary>
-      <img src={`//ipfs.io/ipfs/${hash}`}/>
+      <img src={`//ipfs.io/ipfs/${hash}`} alt=""/>
     </details>
   );
 }

--- a/dapp/src/components/post/PostBody.tsx
+++ b/dapp/src/components/post/PostBody.tsx
@@ -28,7 +28,8 @@ function PostReference({post, thread, value}: {post: Post, thread?: Thread, valu
   const { publish } = usePubSub();
   const postLink = `${value.id}/${value.n}`;
 
-  const refPost = thread?.replies?.find(p => `${p.from.id}/${p.n}` === postLink);
+  const refPost = thread
+    && [thread.op, ...thread.replies].find(p => `${p.from.id}/${p.n}` === postLink);
 
   useEffect(() => {
     const backlink = {
@@ -63,9 +64,9 @@ function PostReference({post, thread, value}: {post: Post, thread?: Thread, valu
 
   const { accounts } = useWeb3();
 
-  const isYou = accounts && accounts[0] && refPost
-    ? accounts[0] === refPost.from.address
-    : false;
+  const isOp = thread && refPost && thread.op.id === refPost.id;
+
+  const isYou = accounts && accounts[0] && refPost && accounts[0] === refPost.from.address;
 
   return (
     <a
@@ -74,7 +75,7 @@ function PostReference({post, thread, value}: {post: Post, thread?: Thread, valu
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
     >
-      &gt;&gt;{postLink}{isYou ? " (You)" : ""}
+      &gt;&gt;{postLink}{isOp ? " (OP)" : ""}{isYou ? " (You)" : ""}
     </a>
   );
 }

--- a/dapp/src/components/post/PostBody.tsx
+++ b/dapp/src/components/post/PostBody.tsx
@@ -1,28 +1,97 @@
 import { Post } from 'dchan';
-import { BACKLINK_HTML_SAFE_REGEX, EXTERNAL_LINK_REGEX, NEWLINE_REGEX, REF_BOARD_HTML_SAFE_REGEX, REF_HTML_SAFE_REGEX, REF_POST_HTML_SAFE_REGEX, SPOILER_REGEX, TEXT_QUOTES_HTML_SAFE_REGEX } from 'dchan/regexps';
 import { Router } from 'router';
-import sanitizeHtml from 'sanitize-html';
+import parseComment, { ParserResult } from 'dchan/postparse';
+import { ReactElement } from 'react';
+
+function TextQuote({children, post}: {children: ParserResult[], post: Post}) {
+  return (
+    <span className="text-quote">
+      &gt;{children.map(v => renderValue(v, post))}
+    </span>
+  );
+}
+
+function Reference({link, children}: {link: string; children: string}) {
+  return (
+    <a
+      className="text-blue-600 visited:text-purple-600 hover:text-blue-500"
+      href={link}
+    >
+      &gt;&gt;{children}
+    </a>
+  );
+}
+
+function Spoiler({children, post}: {children: ParserResult[], post: Post}) {
+  return (
+    <span className="dchan-post-spoiler">
+      {children.map(v => renderValue(v, post))}
+    </span>
+  );
+}
+
+function ExternalLink({link}: {link: string}) {
+  return (
+    <a
+      className="text-blue-600 visited:text-purple-600 hover:text-blue-500"
+      href={link}
+      target="_blank"
+      rel="noreferrer"
+    >
+      {link}
+    </a>
+  );
+}
+
+function IPFSImage({hash}: {hash: string}) {
+  return (
+    <details className="inline">
+      <summary>
+        <a
+          className="text-blue-600 visited:text-purple-600 hover:text-blue-500"
+          href="//ipfs.io/ipfs/$1"
+          target="_blank"
+          rel="noreferrer"
+        >
+          {hash}
+        </a>
+      </summary>
+      <img src={`//ipfs.io/ipfs/${hash}`}/>
+    </details>
+  );
+}
+
+function renderValue(val: ParserResult, post: Post): ReactElement | string {
+  switch(val.type) {
+    case "text":
+      return val.value;
+    case "link":
+      return <ExternalLink link={val.value} />;
+    case "ipfs":
+      return <IPFSImage hash={val.value} />;
+    case "newline":
+      return <br/>;
+    case "textquote":
+      return <TextQuote post={post}>{val.value}</TextQuote>;
+    case "ref":
+      return <Reference link={`#/${val.value}`}>{val.value}</Reference>;
+    case "postref":
+      const baseUrl = `${post.board ? Router.board(post.board) : ""}/${post.thread ? `${post.from.id}/${post.thread.n}/` : ""}`;
+      return <Reference link={`#${baseUrl}${val.value}`}>{val.value}</Reference>;
+    case "boardref":
+      return <Reference link={`#/${val.value[1]}`}>{val.value[0]}</Reference>;
+    case "spoiler":
+      return <Spoiler post={post}>{val.value}</Spoiler>;
+  }
+}
 
 export default function PostBody({post, style = {}}: {style?: any, post: Post}) {
-  const sanitized = sanitizeHtml(post.comment, {allowedTags: []})
-  const baseUrl = `${post.board ? Router.board(post.board) : ""}/${post.thread ? `${post.from.id}/${post.thread.n}/` : ""}`
-
-  let __html = sanitized
-    .replace(TEXT_QUOTES_HTML_SAFE_REGEX, `<span class="text-quote">&gt;$1</span>`) // Text quotes
-    .replace(REF_HTML_SAFE_REGEX, `<a href="#/$1" class="text-blue-600 visited:text-purple-600 hover:text-blue-500">&gt;&gt;$1$2</a>`) // 0x refs
-    .replace(REF_POST_HTML_SAFE_REGEX, `<a href="#${baseUrl}$1" class="text-blue-600 visited:text-purple-600 hover:text-blue-500">&gt;&gt;$1$2</a>`) // Post refs
-    .replace(REF_BOARD_HTML_SAFE_REGEX, `<a href="#/$2" class="text-blue-600 visited:text-purple-600 hover:text-blue-500">&gt;&gt;$1$3</a>`) // Board refs
-    .replace(BACKLINK_HTML_SAFE_REGEX, `<a class="text-blue-600 visited:text-purple-600 hover:text-blue-500" href="#${baseUrl}$1">&gt;&gt;$1$2</a>`) // Post backlinks // @HACK
-    .replace(SPOILER_REGEX, `<span class="dchan-post-spoiler">$1</span>`) // Spoilers
-    .replace(EXTERNAL_LINK_REGEX, `<a class="text-blue-600 visited:text-purple-600 hover:text-blue-500" href="$1" target="_blank" rel="noreferrer">$1</a>`) // Links
-    .replace(NEWLINE_REGEX, `<br>`)
-    
-    return (
-      <div
-        className="inline-block text-left break-words font-sans text-sm max-w-100vw"
-        style={style}
-        dangerouslySetInnerHTML={{
-          __html
-        }}/>
-    )
+  return (
+    <div
+      className="block text-left break-words font-sans text-sm max-w-100vw"
+      style={style}
+    >
+      {parseComment(post.comment).map(v => renderValue(v, post))}
+    </div>
+  )
 }

--- a/dapp/src/components/post/PostHeader.tsx
+++ b/dapp/src/components/post/PostHeader.tsx
@@ -229,6 +229,8 @@ export default function PostHeader({
           <button
             className="text-blue-600 visited:text-purple-600 hover:text-blue-500 px-1"
             onClick={() => focusPost(post)}
+            onMouseEnter={() => publish("POST_HIGHLIGHT", post.id)}
+            onMouseLeave={() => publish("POST_DEHIGHLIGHT", post.id)}
             key={post.id}
           >{`>>${post.n}`}</button>
         ))}

--- a/dapp/src/dchan/postparse.ts
+++ b/dapp/src/dchan/postparse.ts
@@ -1,0 +1,186 @@
+import { regexp as brokenRegexp, string, eof, Parjser } from "parjs";
+import { map, backtrack, then, thenq, qthen, not, many, or, later, mapConst, flatten, between } from "parjs/combinators";
+
+// known bug with parjs
+const regexp: (origRegexp: RegExp) => Parjser<string[]> = brokenRegexp.bind({});
+
+export type TextValue = {
+  type: "text";
+  value: string;
+}
+
+export type LinkValue = {
+  type: "link";
+  value: string;
+}
+
+export type IPFSValue = {
+  type: "ipfs";
+  value: string;
+}
+
+export type NewlineValue = {
+  type: "newline";
+}
+
+export type ReferenceValue = {
+  type: "ref";
+  value: string;
+}
+
+export type PostReferenceValue = {
+  type: "postref";
+  value: string;
+}
+
+export type BoardReferenceValue = {
+  type: "boardref";
+  value: [string, string];
+}
+
+export type SpoilerValue = {
+  type: "spoiler";
+  value: ParserResult[];
+};
+
+export type TextQuoteValue = {
+  type: "textquote";
+  value: ParserResult[];
+}
+
+export type ParserResult = TextValue
+                         | LinkValue
+                         | IPFSValue
+                         | NewlineValue
+                         | ReferenceValue
+                         | PostReferenceValue
+                         | BoardReferenceValue
+                         | SpoilerValue
+                         | TextQuoteValue;
+
+function alt<T>(p1: Parjser<T>, ...ps: Parjser<T>[]): Parjser<T> {
+  // @ts-ignore
+  return or(...ps)(p1);
+}
+
+function mergeText(vals: ParserResult[]): ParserResult[] {
+  let ret: ParserResult[] = []
+  if (vals.length === 0) {
+    return vals;
+  }
+  let curVal = vals[0];
+  for (let i = 1; i < vals.length; i++) {
+    let val = vals[i];
+    if (curVal.type === "text" && val.type === "text") {
+      curVal.value += val.value;
+    } else {
+      ret.push(curVal);
+      curVal = vals[i];
+    }
+  }
+  ret.push(curVal);
+  return ret;
+}
+
+// qthen(a)(b) yields a
+// thenq(a)(b) yields b
+
+const text: Parjser<TextValue> = regexp(/.[^[\n>hfQ]*/g).pipe(
+  map(v => ({type: "text", value: v[0]}))
+);
+
+const ipfsHash: Parjser<IPFSValue> = regexp(/(Qm[1-9A-Za-z]{44})/).pipe(
+  map(v => ({type: "ipfs", value: v[0]}))
+)
+
+const newline: Parjser<NewlineValue> = string("\n").pipe(
+  mapConst({type: "newline"})
+);
+
+const reference: Parjser<ReferenceValue> = regexp(/>>(0[xX][0-9a-fA-F]+)/).pipe(
+  map(vals => {
+    return {type: "ref", value: vals[1]}
+  })
+);
+
+const postReference: Parjser<PostReferenceValue> = regexp(/>>((?:0[xX][0-9a-fA-F]+)\/\d+)/).pipe(
+  map(vals => {
+    return {type: "postref", value: vals[1]};
+  })
+);
+
+const boardReference: Parjser<BoardReferenceValue> = regexp(/>>(\/(?:[a-zA-Z]+)\/(0[xX][0-9a-fA-F]+(?:\/\d+)?)?)/).pipe(
+  map(vals => {
+    return {type: "boardref", value: [vals[1], vals[2]]};
+  })
+);
+
+const altReference = alt<ParserResult>(boardReference, postReference, reference);
+
+const newlineReference: Parjser<[NewlineValue, ReferenceValue]> = regexp(/\n>>(0[xX][0-9a-fA-F]+)/).pipe(
+  map(vals => {
+    return [{type: "newline"}, {type: "ref", value: vals[1]}]
+  })
+);
+
+const newlinePostReference: Parjser<[NewlineValue, PostReferenceValue]> = regexp(/\n>>((?:0[xX][0-9a-fA-F]+)\/\d+)/).pipe(
+  map(vals => {
+    return [{type: "newline"}, {type: "postref", value: vals[1]}]
+  })
+);
+
+const newlineBoardReference: Parjser<[NewlineValue, BoardReferenceValue]> = regexp(/\n>>(\/(?:[a-zA-Z]+)\/(0[xX][0-9a-fA-F]+(?:\/\d+)?)?)/).pipe(
+  map(vals => {
+    return [{type: "newline"}, {type: "boardref", value: [vals[1], vals[2]]}];
+  })
+);
+
+const newlineAltReference = alt<[NewlineValue, ParserResult]>(newlineBoardReference, newlinePostReference, newlineReference);
+
+const link: Parjser<LinkValue> = regexp(/(\b(https?|ftp|file):\/\/[-A-Z0-9+&@#/%?=~_|!:,.;]*[-A-Z0-9+&@#/%=~_|])/i).pipe(
+  map(val => ({type: "link", value: val[0]}))
+);
+
+const spoilerBody = later<ParserResult>();
+
+const spoiler: Parjser<SpoilerValue> = spoilerBody.pipe(
+  many(),
+  between("[spoiler]", "[/spoiler]"),
+  map(value => ({type: "spoiler", value: mergeText(value)}))
+);
+
+const spoilerText: Parjser<TextValue> = regexp(/[^[][^[\n>hfQ]*/g).pipe(
+  map(v => ({type: "text", value: v[0]}))
+);
+
+spoilerBody.init(
+  alt<ParserResult>(altReference, spoiler, link, ipfsHash, spoilerText)
+);
+
+const commonBase = alt<ParserResult>(spoiler, link, ipfsHash, text);
+
+const endline = alt(string("\n"), eof());
+
+const textQuoteStart: Parjser<TextQuoteValue> = string(">").pipe(
+  qthen(alt<ParserResult>(altReference, commonBase).pipe(many())),
+  thenq(endline.pipe(backtrack())),
+  map(value => ({type: "textquote", value: mergeText(value)}))
+);
+
+const textQuote: Parjser<[NewlineValue, TextQuoteValue]> = string("\n>").pipe(
+  qthen(alt<ParserResult>(altReference, commonBase).pipe(many())),
+  thenq(endline.pipe(backtrack())),
+  map(value => [{type: "newline"}, {type: "textquote", value: mergeText(value)}])
+);
+
+const post: Parjser<ParserResult[]> = alt<ParserResult>(altReference, textQuoteStart, newline, commonBase).pipe(
+  then(alt<any>(newlineAltReference, altReference, textQuote, newline, commonBase).pipe(many(), flatten())),
+  map(v => mergeText([v[0], ...v[1]])),
+);
+
+export default function parseComment(comment: string): ParserResult[] {
+  if (comment === "") {
+    return [];
+  }
+  return post.parse(comment).value;
+}

--- a/dapp/src/dchan/postparse.ts
+++ b/dapp/src/dchan/postparse.ts
@@ -100,41 +100,29 @@ const newline: Parjser<NewlineValue> = string("\n").pipe(
 );
 
 const reference: Parjser<ReferenceValue> = regexp(/>>(0[xX][0-9a-fA-F]+)/).pipe(
-  map(vals => {
-    return {type: "ref", id: vals[1]}
-  })
+  map(vals => ({type: "ref", id: vals[1]}))
 );
 
 const postReference: Parjser<PostReferenceValue> = regexp(/>>(0[xX][0-9a-fA-F]+)\/(\d+)/).pipe(
-  map(vals => {
-    return {type: "postref", id: vals[1], n: vals[2]};
-  })
+  map(vals => ({type: "postref", id: vals[1], n: vals[2]}))
 );
 
 const boardReference: Parjser<BoardReferenceValue> = regexp(/>>(\/[a-zA-Z]+\/)(0[xX][0-9a-fA-F]+(?:\/\d+)?)?/).pipe(
-  map(vals => {
-    return {type: "boardref", board: vals[1], id: vals[2]};
-  })
+  map(vals => ({type: "boardref", board: vals[1], id: vals[2]}))
 );
 
 const altReference = alt<ParserResult>(boardReference, postReference, reference);
 
 const newlineReference: Parjser<[NewlineValue, ReferenceValue]> = regexp(/\n>>(0[xX][0-9a-fA-F]+)/).pipe(
-  map(vals => {
-    return [{type: "newline"}, {type: "ref", id: vals[1]}];
-  })
+  map(vals => [{type: "newline"}, {type: "ref", id: vals[1]}])
 );
 
 const newlinePostReference: Parjser<[NewlineValue, PostReferenceValue]> = regexp(/\n>>(0[xX][0-9a-fA-F]+)\/(\d+)/).pipe(
-  map(vals => {
-    return [{type: "newline"}, {type: "postref", id: vals[1], n: vals[2]}];
-  })
+  map(vals => [{type: "newline"}, {type: "postref", id: vals[1], n: vals[2]}])
 );
 
 const newlineBoardReference: Parjser<[NewlineValue, BoardReferenceValue]> = regexp(/\n>>(\/[a-zA-Z]+\/)(0[xX][0-9a-fA-F]+(?:\/\d+)?)?/).pipe(
-  map(vals => {
-    return [{type: "newline"}, {type: "boardref", board: vals[1], id: vals[2]}];
-  })
+  map(vals => [{type: "newline"}, {type: "boardref", board: vals[1], id: vals[2]}])
 );
 
 const newlineAltReference = alt<[NewlineValue, ParserResult]>(newlineBoardReference, newlinePostReference, newlineReference);
@@ -156,7 +144,7 @@ const spoilerText: Parjser<TextValue> = regexp(/[^[][^[\n>hfQ]*/g).pipe(
 );
 
 spoilerBody.init(
-  alt<ParserResult>(altReference, spoiler, link, ipfsHash, spoilerText)
+  alt<ParserResult>(altReference, spoiler, link, ipfsHash, newline, spoilerText)
 );
 
 const commonBase = alt<ParserResult>(spoiler, link, ipfsHash, text);

--- a/dapp/yarn.lock
+++ b/dapp/yarn.lock
@@ -4723,6 +4723,13 @@ change-case@^4.0.0:
     snake-case "^3.0.4"
     tslib "^2.0.3"
 
+char-info@^0.3.1:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/char-info/-/char-info-0.3.2.tgz#d4c4d034245c864d1ab17152cd31746b3bd4f0d0"
+  integrity sha512-6P6KW8crZx+N857wZalB4FreR+PhheSLmAk22c8zbQsFhsDxZP1aTDfmOjrzddgp1IBOl53b0Z8kDQrwh4B//A==
+  dependencies:
+    node-interval-tree "^1.3.3"
+
 char-regex@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
@@ -10644,6 +10651,13 @@ node-int64@^0.4.0:
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
   integrity sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=
 
+node-interval-tree@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/node-interval-tree/-/node-interval-tree-1.3.3.tgz#15ffb904cde08270214acace8dc7653e89ae32b7"
+  integrity sha512-K9vk96HdTK5fEipJwxSvIIqwTqr4e3HRJeJrNxBSeVMNSC/JWARRaX7etOLOuTmrRMeOI/K5TCJu3aWIwZiNTw==
+  dependencies:
+    shallowequal "^1.0.2"
+
 node-libs-browser@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/node-libs-browser/-/node-libs-browser-2.2.1.tgz#b64f513d18338625f90346d27b0d235e631f6425"
@@ -11217,6 +11231,14 @@ parent-module@^1.0.0:
   integrity sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==
   dependencies:
     callsites "^3.0.0"
+
+parjs@^0.12.7:
+  version "0.12.7"
+  resolved "https://registry.yarnpkg.com/parjs/-/parjs-0.12.7.tgz#9dde4975dbbb2f48d4b484524cb359d02395fb72"
+  integrity sha512-aKw+vsSMBdZNdxcetIwi5mnmFckuwxTz7dKu07wEzrNjKYtvhRlrlla3b4GAEmGMyAWhrocLrUcbSGvmMZMU3Q==
+  dependencies:
+    char-info "^0.3.1"
+    lodash "^4.17.13"
 
 parse-asn1@^5.0.0, parse-asn1@^5.1.5:
   version "5.1.6"
@@ -13600,7 +13622,7 @@ sha.js@^2.4.0, sha.js@^2.4.11, sha.js@^2.4.8:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
-shallowequal@^1.1.0:
+shallowequal@^1.0.2, shallowequal@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
   integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==


### PR DESCRIPTION
- Post content formatting completely overhauled
  - Uses a custom parser (recursive things like nested [spoiler] tags now work)
  - Rendered using React elements instead of via HTML and regex
  - Parjs added as a dependency
- Hovering over a post reference now highlights the post in the thread
- (You) support