### PR TITLE
Time travel patch

### DIFF
--- a/dapp/src/router.ts
+++ b/dapp/src/router.ts
@@ -30,7 +30,8 @@ export abstract class Router {
         name,
         id
     }: Board, viewMode?: string) {
-        return !!name && !!id ? `/${name}/${id}${viewMode === "catalog" ? "/catalog" : ""}` : undefined
+        const urlViewMode = viewMode && ["catalog", "index"].includes(viewMode) ? `/${viewMode}` : "";
+        return !!name && !!id ? `/${name}/${id}${urlViewMode}` : undefined
     }
 
     public static posts() {


### PR DESCRIPTION
Turns out in my time travel widget refactor that I completely forgot to distinguish between actually time travelling and not, which caused the page to change to the time travel url unnecessarily, and it also meant that the widget wouldn't keep in sync with the latest block. That should all be fixed now.

Also `Router.board(board, boardMode)` didn't actually recognise the index URL as valid (lol), so it would switch you to the default board page, meaning if you try to go from a thread to the board index, it'd just send you to catalog instead (unless you set your default board mode to index). All fixed now.