### PR TITLE
Label tweaks

### DIFF
--- a/dapp/src/components/AddressLabel.tsx
+++ b/dapp/src/components/AddressLabel.tsx
@@ -1,5 +1,6 @@
-import { shortenAddress, backgroundColorAddress } from "dchan";
+import { shortenAddress } from "dchan";
 import { trim } from "lodash";
+import IdLabel from "./IdLabel";
 const keccak256 = require('keccak256')
 
 export default function AddressLabel({ address, className = "", etherscannable = true }: { className?: string, address: string, etherscannable?: boolean }) {
@@ -10,11 +11,9 @@ export default function AddressLabel({ address, className = "", etherscannable =
       href={etherscannable ? `https://polygonscan.com/address/${address}` : "javascript:void(0)"}
       target={etherscannable ? `_blank` : ""}
     >
-      <span
-        className={[className, LABEL_CLASSNAME].join(" ")}
-        style={{ backgroundColor: backgroundColorAddress(address) }}>
+      <IdLabel id={address} className={className}>
         {trim(btoa(keccak256(address).toString('hex')), "=").substr(-8, 8)}
-      </span>
+      </IdLabel>
       @<abbr
         className="text-xs font-mono"
         style={{ textDecoration: "none" }} title={address}>
@@ -23,5 +22,3 @@ export default function AddressLabel({ address, className = "", etherscannable =
     </a>
   );
 }
-
-export const LABEL_CLASSNAME = "font-mono font-bold text-readable-anywhere pt-0.5 px-0.5 mx-0.5 rounded opacity-75 hover:opacity-100 text-xs whitespace-nowrap"

--- a/dapp/src/components/AddressLabel.tsx
+++ b/dapp/src/components/AddressLabel.tsx
@@ -1,7 +1,14 @@
 import { shortenAddress } from "dchan";
-import { trim } from "lodash";
 import IdLabel from "./IdLabel";
-const keccak256 = require('keccak256')
+const keccak256 = require('keccak256');
+
+function getCondensedHash(address: string): string {
+  let buffer: Buffer = keccak256(address);
+  for (let i = 6; i < 32; i++) {
+    buffer[i % 6] ^= buffer[i];
+  }
+  return buffer.slice(0, 6).toString("base64");
+}
 
 export default function AddressLabel({ address, className = "", etherscannable = true }: { className?: string, address: string, etherscannable?: boolean }) {
   return (
@@ -12,7 +19,7 @@ export default function AddressLabel({ address, className = "", etherscannable =
       target={etherscannable ? `_blank` : ""}
     >
       <IdLabel id={address} className={className}>
-        {trim(btoa(keccak256(address).toString('hex')), "=").substr(-8, 8)}
+        {getCondensedHash(address)}
       </IdLabel>
       @<abbr
         className="text-xs font-mono"

--- a/dapp/src/components/BoardLink.tsx
+++ b/dapp/src/components/BoardLink.tsx
@@ -1,20 +1,15 @@
-import { backgroundColorAddress, Board } from "dchan";
+import { Board } from "dchan";
 import { Link } from "react-router-dom";
 import { Router } from "router";
-import { LABEL_CLASSNAME } from "./AddressLabel";
+import IdLabel from "./IdLabel";
 
 export default function BoardLink({ board }: { board: Board }) {
   return (
     <Link
-      style={{ backgroundColor: backgroundColorAddress(board.id) }}
-      className={
-        LABEL_CLASSNAME +
-        " text-blue-600 visited:text-purple-600 hover:text-blue-500 hover:text-opacity-100"
-      }
       title={board.title}
       to={`${Router.board(board)}`}
     >
-      {board.name}
+      <IdLabel id={board.id}>{board.name}</IdLabel>
     </Link>
   );
 }

--- a/dapp/src/components/IdLabel.tsx
+++ b/dapp/src/components/IdLabel.tsx
@@ -3,19 +3,23 @@ import { backgroundColorAddress, shortenAddress } from "dchan";
 export default function IdLabel({
   id,
   className = "",
+  children
 }: {
   className?: string;
   id: string;
+  children?: any;
 }) {
   const shortId = shortenAddress(id);
+  if (children == null) {
+    children = shortId;
+  }
 
   return (
     <span
       style={{ backgroundColor: backgroundColorAddress(shortId) }}
       className={[className, LABEL_CLASSNAME].join(" ")}
-      // eslint-disable-next-line
     >
-      {shortId}
+      {children}
     </span>
   );
 }


### PR DESCRIPTION
- AddressLabel and BoardLink now use IdLabel
- AddressLabel now uses all bytes of the address hash when calculating ID

Not strictly necessary to add in, but it does allow the full range of base64 characters to appear (base16 encoded in base64 starts to look a little samey), and the current implementation was technically only using the last couple bytes of the hash, so it should add in a bit more randomness to IDs.