### PR TITLE
Fix time travel

### DIFF
--- a/dapp/src/components/TimeTravelWidget.tsx
+++ b/dapp/src/components/TimeTravelWidget.tsx
@@ -103,7 +103,6 @@ export default function TimeTravelWidget({
             ? `${baseUrl}?block=${b.number}`
             : undefined;
 
-          setPrevQueriedBlock(b.number);
           url && history.replace(url);
           setTimeTraveledToNumber(`${b.number}`);
           changeBlock(b);
@@ -121,7 +120,6 @@ export default function TimeTravelWidget({
           : `${baseUrl}`
         : undefined;
 
-      setPrevQueriedBlock(block);
       url && history.replace(url);
 
       if (block) {


### PR DESCRIPTION
So this is rather frustrating. The reason time travel was broken was because each travel operation was doing two things: changing the URL to the new block, and updating prevQueriedBlock to the new block. My assumption up until now was that code was effectively atomic, and would be executed completely before react renders would take place, so I could both change the internal state of the time travel component and travel in a single step and keep them in sync. Unfortunately, it doesn't seem like that's the case (despite seemingly being so this whole time). What was happening was that the code was setting prevQueriedBlock, and this was triggering a re-render *before* the new URL could be written, and the component would notice the mismatch and resync itself with the (incorrect) URL. Somehow the new URL would never be written at all in this scenario. Reversing the order of operations would cause it to write the new URL, but not to prevQueriedBlock; this works, but it now means the code is doing a query when the URL change occurs, and another when it realises prevQueriedBlock is out of sync.

This fix isn't perfect, but it works. I honestly don't know how to get around this, since apparently I can't pre-emptively update the widget to expect the URL change without also re-rendering the damn widget, but whatever. You could skip out a query for the block slider by having the query occur only on URL change, but the date changer has no choice but to do two queries without either getting around this issue or using some weird history state shit I can't be bothered to figure out. 