### PR TITLE
Homepage revamp

### DIFF
--- a/dapp/src/assets/styles/components.scss
+++ b/dapp/src/assets/styles/components.scss
@@ -44,26 +44,6 @@
 }
 */
 
-.dchan-post-expand[open] > summary {
-    visibility: hidden;
-    list-style: none;
-    position: absolute;
-    background-color: rgba(0,0,0,0);
-    color: rgba(0,0,0,0);
-    user-select: none;
-    
-    &::before { 
-        visibility: visible;
-        color: black;
-        content:"▼";
-        opacity: 1;
-        z-index: 9001;
-        position: relative;
-        padding: 0.2rem;
-        font-size: 0.75rem;
-    }
-}
-
 .dchan-form-expand[open] .dchan-post-fab.absolute {
   display: none;
 }

--- a/dapp/src/components/FAQCard.tsx
+++ b/dapp/src/components/FAQCard.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import { singletonHook } from "react-singleton-hook";
 import OverlayComponent from "./OverlayComponent";
 
-function TheGraph() {
+export function TheGraph() {
   return (
     <span>
       <a
@@ -30,7 +30,7 @@ function TheGraph() {
   );
 }
 
-function Polygon() {
+export function Polygon() {
   return (
     <a
       className="text-blue-600 visited:text-purple-600"
@@ -45,7 +45,7 @@ function Polygon() {
 
 export function FAQCard({onExit, className}: {onExit: () => void, className?: string}) {
   return (
-    <Card title={<span>FAQ</span>} className={className} bodyClassName="flex overflow-y-scroll overscroll-contain">
+    <Card title={<span>FAQ</span>} className={className} bodyClassName="flex overflow-y-auto overscroll-contain">
       <div className="text-left p-8 text-sm">
         <div className="pb-2">
           <strong>Q: What is this?</strong>

--- a/dapp/src/components/Footer.tsx
+++ b/dapp/src/components/Footer.tsx
@@ -13,7 +13,7 @@ export default function Footer({
   className?: string;
 }) {
   return (
-    <div className={` bg-primary ${className}`}>
+    <div className={`bg-primary ${className}`}>
       <div id="bottom" />
       <footer className="mt-4">
         {showContentDisclaimer ? (

--- a/dapp/src/components/Footer.tsx
+++ b/dapp/src/components/Footer.tsx
@@ -7,11 +7,13 @@ import AbuseButton from "./AbuseCard";
 
 export default function Footer({
   showContentDisclaimer = false,
+  className = "mt-auto",
 }: {
   showContentDisclaimer?: boolean;
+  className?: string;
 }) {
   return (
-    <div className="mt-auto">
+    <div className={` bg-primary ${className}`}>
       <div id="bottom" />
       <footer className="mt-4">
         {showContentDisclaimer ? (

--- a/dapp/src/components/Footer.tsx
+++ b/dapp/src/components/Footer.tsx
@@ -11,7 +11,7 @@ export default function Footer({
   showContentDisclaimer?: boolean;
 }) {
   return (
-    <div>
+    <div className="mt-auto">
       <div id="bottom" />
       <footer className="mt-4">
         {showContentDisclaimer ? (

--- a/dapp/src/components/LatestPostsCard.tsx
+++ b/dapp/src/components/LatestPostsCard.tsx
@@ -1,7 +1,6 @@
 import { useQuery } from "@apollo/react-hooks";
 import { Post } from "dchan";
 import POSTS_GET_LAST from "graphql/queries/posts_get_last";
-import Card from "./Card";
 import Loading from "./Loading";
 import PostSearchResult from "./PostSearchResult";
 
@@ -14,14 +13,12 @@ export default function LatestPostsCard() {
   });
 
   return (
-    <Card className="mx-auto pt-4" title={<span>Latest Posts</span>}>
-      <div>
-        {loading && !data ? (
-          <Loading />
-        ) : (
-          data?.posts?.map((post) => <PostSearchResult post={post} key={post.id} />)
-        )}
-      </div>
-    </Card>
+    <div>
+      {loading && !data ? (
+        <Loading />
+      ) : (
+        data?.posts?.map((post) => <PostSearchResult post={post} key={post.id} />)
+      )}
+    </div>
   );
 }

--- a/dapp/src/components/LatestPostsCard.tsx
+++ b/dapp/src/components/LatestPostsCard.tsx
@@ -1,15 +1,17 @@
 import { useQuery } from "@apollo/react-hooks";
 import { Post } from "dchan";
 import POSTS_GET_LAST from "graphql/queries/posts_get_last";
+import POSTS_GET_LAST_BLOCK from "graphql/queries/posts_get_last_block";
 import Loading from "./Loading";
 import PostSearchResult from "./PostSearchResult";
 
-export default function LatestPostsCard() {
-  const { query } = {
-    query: POSTS_GET_LAST,
-  };
+export default function LatestPostsCard({block}: {block?: number}) {
+  const query = block ? POSTS_GET_LAST_BLOCK : POSTS_GET_LAST
   const { loading, data } = useQuery<{ posts: Post[] }, any>(query, {
     pollInterval: 5_000,
+    variables: {
+      block,
+    }
   });
 
   return (
@@ -17,7 +19,7 @@ export default function LatestPostsCard() {
       {loading && !data ? (
         <Loading />
       ) : (
-        data?.posts?.map((post) => <PostSearchResult post={post} key={post.id} />)
+        data?.posts?.map((post) => <PostSearchResult post={post} key={post.id} block={block ? `${block}` : undefined} />)
       )}
     </div>
   );

--- a/dapp/src/components/PopularBoardsCard.tsx
+++ b/dapp/src/components/PopularBoardsCard.tsx
@@ -9,6 +9,7 @@ export default function PopularBoardsCard({block}: {block?: number}) {
   const query = block ? BOARDS_LIST_MOST_POPULAR_BLOCK : BOARDS_LIST_MOST_POPULAR;
   const { loading, data } = useQuery<{ boards: Board[] }, any>(query, {
     pollInterval: 30_000,
+    fetchPolicy: block ? "cache-first" : "network-only",
     variables: {
       block
     },

--- a/dapp/src/components/PopularBoardsCard.tsx
+++ b/dapp/src/components/PopularBoardsCard.tsx
@@ -1,20 +1,22 @@
 import { useQuery } from "@apollo/react-hooks";
 import { Board } from "dchan";
 import BOARDS_LIST_MOST_POPULAR from "graphql/queries/boards/list_most_popular";
+import BOARDS_LIST_MOST_POPULAR_BLOCK from "graphql/queries/boards/list_most_popular_block";
 import { Link } from "react-router-dom";
 import BoardList from "./board/list";
 
-export default function PopularBoardsCard() {
-  const { query } = {
-    query: BOARDS_LIST_MOST_POPULAR,
-  };
+export default function PopularBoardsCard({block}: {block?: number}) {
+  const query = block ? BOARDS_LIST_MOST_POPULAR_BLOCK : BOARDS_LIST_MOST_POPULAR;
   const { loading, data } = useQuery<{ boards: Board[] }, any>(query, {
     pollInterval: 30_000,
+    variables: {
+      block
+    },
   });
 
   return (
     <div>
-      <BoardList className="grid" loading={loading} boards={data?.boards}></BoardList>
+      <BoardList className="grid" loading={loading} boards={data?.boards} block={block} />
       <div className="p-4">
         [
         <Link

--- a/dapp/src/components/PopularBoardsCard.tsx
+++ b/dapp/src/components/PopularBoardsCard.tsx
@@ -3,7 +3,6 @@ import { Board } from "dchan";
 import BOARDS_LIST_MOST_POPULAR from "graphql/queries/boards/list_most_popular";
 import { Link } from "react-router-dom";
 import BoardList from "./board/list";
-import Card from "./Card";
 
 export default function PopularBoardsCard() {
   const { query } = {
@@ -14,20 +13,18 @@ export default function PopularBoardsCard() {
   });
 
   return (
-    <Card className="p-2 pt-4" title={<span>Popular boards</span>}>
-      <div>
-        <BoardList className="grid" loading={loading} boards={data?.boards}></BoardList>
-        <div className="p-4">
-          [
-          <Link
-            className="text-blue-600 visited:text-purple-600 hover:text-blue-500 py-1 px-4"
-            to="/_/boards"
-          >
-            More boards
-          </Link>
-          ]
-        </div>
+    <div>
+      <BoardList className="grid" loading={loading} boards={data?.boards}></BoardList>
+      <div className="p-4">
+        [
+        <Link
+          className="text-blue-600 visited:text-purple-600 hover:text-blue-500 py-1 px-4"
+          to="/_/boards"
+        >
+          More boards
+        </Link>
+        ]
       </div>
-    </Card>
+    </div>
   );
 }

--- a/dapp/src/components/PopularThreadsCard.tsx
+++ b/dapp/src/components/PopularThreadsCard.tsx
@@ -4,11 +4,16 @@ import THREADS_LIST_MOST_POPULAR from "graphql/queries/threads/list_most_popular
 import THREADS_LIST_MOST_POPULAR_BLOCK from "graphql/queries/threads/list_most_popular_block";
 import CatalogView from "./CatalogView";
 import Loading from "./Loading";
+import { useTraveledBlock } from "./TimeTravelWidget";
 import { DateTime } from "luxon";
 import { useMemo } from "react";
 
 export default function PopularThreadsCard({block} : {block?: number}) {
-  const cutoff = useMemo(() => Math.floor(DateTime.now().toSeconds()-604800), [])
+  const currentBlock = useTraveledBlock();
+  console.log(`currentBlock is ${JSON.stringify(currentBlock)}`);
+  const timestamp = currentBlock ? parseInt(currentBlock.timestamp) : DateTime.now().toSeconds();
+  console.log(`timestamp is ${timestamp}`);
+  const cutoff = useMemo(() => Math.floor(timestamp-604800), [currentBlock])
 
   const query = block ? THREADS_LIST_MOST_POPULAR_BLOCK : THREADS_LIST_MOST_POPULAR;
   const { loading, data } = useQuery<{ threads: Thread[] }, any>(query, {
@@ -16,7 +21,7 @@ export default function PopularThreadsCard({block} : {block?: number}) {
     fetchPolicy: block ? "cache-first" : "network-only",
     variables: {
       cutoff,
-      block,
+      block: currentBlock ? parseInt(currentBlock.number) : block,
     },
   });
 

--- a/dapp/src/components/PopularThreadsCard.tsx
+++ b/dapp/src/components/PopularThreadsCard.tsx
@@ -10,10 +10,12 @@ import { useMemo } from "react";
 
 export default function PopularThreadsCard({block} : {block?: number}) {
   const currentBlock = useTraveledBlock();
-  console.log(`currentBlock is ${JSON.stringify(currentBlock)}`);
-  const timestamp = currentBlock ? parseInt(currentBlock.timestamp) : DateTime.now().toSeconds();
-  console.log(`timestamp is ${timestamp}`);
-  const cutoff = useMemo(() => Math.floor(timestamp-604800), [currentBlock])
+  const cutoff = useMemo(
+    () => Math.floor(
+      (currentBlock ? parseInt(currentBlock.timestamp) : DateTime.now().toSeconds()) - 604800
+    ),
+    [currentBlock]
+  );
 
   const query = block ? THREADS_LIST_MOST_POPULAR_BLOCK : THREADS_LIST_MOST_POPULAR;
   const { loading, data } = useQuery<{ threads: Thread[] }, any>(query, {

--- a/dapp/src/components/PopularThreadsCard.tsx
+++ b/dapp/src/components/PopularThreadsCard.tsx
@@ -1,25 +1,25 @@
 import { useQuery } from "@apollo/react-hooks";
 import { Thread } from "dchan";
 import THREADS_LIST_MOST_POPULAR from "graphql/queries/threads/list_most_popular";
+import THREADS_LIST_MOST_POPULAR_BLOCK from "graphql/queries/threads/list_most_popular_block";
 import CatalogView from "./CatalogView";
 import Loading from "./Loading";
 import { DateTime } from "luxon";
 import { useMemo } from "react";
 
-export default function PopularThreadsCard() {
+export default function PopularThreadsCard({block} : {block?: number}) {
   const cutoff = useMemo(() => Math.floor(DateTime.now().toSeconds()-604800), [])
 
-  const { query } = {
-    query: THREADS_LIST_MOST_POPULAR,
-  };
+  const query = block ? THREADS_LIST_MOST_POPULAR_BLOCK : THREADS_LIST_MOST_POPULAR;
   const { loading, data } = useQuery<{ threads: Thread[] }, any>(query, {
     pollInterval: 30_000,
     variables: {
-      cutoff
-    }
+      cutoff,
+      block,
+    },
   });
 
   return loading
     ? <Loading />
-    : <CatalogView threads={data?.threads || []} showBoard={true} />;
+    : <CatalogView threads={data?.threads || []} showBoard={true} block={block} />;
 }

--- a/dapp/src/components/PopularThreadsCard.tsx
+++ b/dapp/src/components/PopularThreadsCard.tsx
@@ -13,6 +13,7 @@ export default function PopularThreadsCard({block} : {block?: number}) {
   const query = block ? THREADS_LIST_MOST_POPULAR_BLOCK : THREADS_LIST_MOST_POPULAR;
   const { loading, data } = useQuery<{ threads: Thread[] }, any>(query, {
     pollInterval: 30_000,
+    fetchPolicy: block ? "cache-first" : "network-only",
     variables: {
       cutoff,
       block,

--- a/dapp/src/components/PopularThreadsCard.tsx
+++ b/dapp/src/components/PopularThreadsCard.tsx
@@ -2,7 +2,6 @@ import { useQuery } from "@apollo/react-hooks";
 import { Thread } from "dchan";
 import THREADS_LIST_MOST_POPULAR from "graphql/queries/threads/list_most_popular";
 import CatalogView from "./CatalogView";
-import Card from "./Card";
 import Loading from "./Loading";
 import { DateTime } from "luxon";
 import { useMemo } from "react";
@@ -20,9 +19,7 @@ export default function PopularThreadsCard() {
     }
   });
 
-  return (
-    <Card className="max-w-initial p-2 pt-4" title={<span>Popular threads</span>}>
-      {loading ? <Loading /> : <CatalogView threads={data?.threads || []} showBoard={true} />}
-    </Card>
-  );
+  return loading
+    ? <Loading />
+    : <CatalogView threads={data?.threads || []} showBoard={true} />;
 }

--- a/dapp/src/components/PopularThreadsCard.tsx
+++ b/dapp/src/components/PopularThreadsCard.tsx
@@ -21,7 +21,7 @@ export default function PopularThreadsCard() {
   });
 
   return (
-    <Card className="w-100vw max-w-initial p-2 pt-4" title={<span>Popular threads</span>}>
+    <Card className="max-w-initial p-2 pt-4" title={<span>Popular threads</span>}>
       {loading ? <Loading /> : <CatalogView threads={data?.threads || []} showBoard={true} />}
     </Card>
   );

--- a/dapp/src/components/PostSearchResult.tsx
+++ b/dapp/src/components/PostSearchResult.tsx
@@ -5,7 +5,7 @@ import PostComponent from "./post/Post";
 
 export default function PostSearchResult({ post, block }: { post: Post, block?: string }) {
   return (
-    <div className="flex flex-wrap my-2">
+    <div className="my-2">
       <PostComponent
         key={post.id}
         post={post}

--- a/dapp/src/components/PostSearchResult.tsx
+++ b/dapp/src/components/PostSearchResult.tsx
@@ -20,7 +20,7 @@ export default function PostSearchResult({ post, block }: { post: Post, block?: 
             <span className="p-1 whitespace-nowrap">
               [
               <Link
-                to={`/${post.id}`}
+                to={`/${post.id}${block ? `?block=${block}` : ""}`}
                 className="text-blue-600 visited:text-purple-600 hover:text-blue-500 inline"
               >
                 View

--- a/dapp/src/components/SearchWidget.tsx
+++ b/dapp/src/components/SearchWidget.tsx
@@ -13,7 +13,12 @@ export default function SearchWidget({
   const [displayInput, setDisplayInput] = useState<string>(search || "");
   const setSearch = useCallback(
     (search: string) => {
-      history.push(`${baseUrl}${search ? `?s=${search}` : ``}`);
+      const newUrl = search
+        ? baseUrl.includes("?")
+          ? `${baseUrl}&s=${search}`
+          : `${baseUrl}?s=${search}`
+        : baseUrl;
+      history.push(newUrl);
     },
     [history, baseUrl]
   );

--- a/dapp/src/components/TabbedCard.tsx
+++ b/dapp/src/components/TabbedCard.tsx
@@ -1,0 +1,51 @@
+import React, { useState } from "react";
+
+
+export default function TabbedCard({
+  children,
+  className = "",
+}: {
+  children: Map<string, any>;
+  className?: string;
+}) {
+  const [currentChild, setCurrentChild] = useState<string>(children.keys().next().value);
+  let displayChild = currentChild;
+  if (!children.has(currentChild)) {
+    displayChild = children.keys().next().value;
+  }
+  return (
+    <article className={`max-h-full ${className}`}>
+      <header className="bg-white border border-black flex flex-row justify-evenly" style={{flex: "0 1 auto"}}>
+        {Array.from(children.keys()).map((key, index) => (
+          <React.Fragment key={key}>
+            <div
+              className={[
+                "bg-highlight py-1 px-4 w-full font-bold",
+                key === displayChild ? "opacity-100" : "opacity-80 hover:opacity-100"
+              ].join(" ")}
+              onClick={() => {
+                setCurrentChild(key);
+              }}
+            >
+              {key}
+            </div>
+            {index < children.size-1 ? <div className="border-l border-black"/> : null}
+          </React.Fragment>
+        ))}
+      </header>
+      <section className={`bg-white max-w-full border border-black border-t-0 p-4 overflow-y-auto`} style={{flex: "1 1 auto"}}>
+        {Array.from(children.entries()).map(([key, value]) => (
+          <div
+            key={key}
+            className={[
+              "h-min",
+              key !== displayChild ? "hidden" : ""
+            ].join(" ")}
+          >
+            {value}
+          </div>
+        ))}
+      </section>
+    </article>
+  );
+}

--- a/dapp/src/components/TabbedCard.tsx
+++ b/dapp/src/components/TabbedCard.tsx
@@ -18,7 +18,7 @@ export default function TabbedCard({
       <header className="bg-white border border-black flex flex-row justify-evenly" style={{flex: "0 1 auto"}}>
         {Array.from(children.keys()).map((key, index) => (
           <React.Fragment key={key}>
-            <div
+            <button
               className={[
                 "bg-highlight py-1 px-4 w-full font-bold",
                 key === displayChild ? "opacity-100" : "opacity-80 hover:opacity-100"
@@ -28,7 +28,7 @@ export default function TabbedCard({
               }}
             >
               {key}
-            </div>
+            </button>
             {index < children.size-1 ? <div className="border-l border-black"/> : null}
           </React.Fragment>
         ))}

--- a/dapp/src/components/TabbedCard.tsx
+++ b/dapp/src/components/TabbedCard.tsx
@@ -14,7 +14,7 @@ export default function TabbedCard({
     displayChild = children.keys().next().value;
   }
   return (
-    <article className={`max-h-full ${className}`}>
+    <article className={`${className}`}>
       <header className="bg-white border border-black flex flex-row justify-evenly" style={{flex: "0 1 auto"}}>
         {Array.from(children.keys()).map((key, index) => (
           <React.Fragment key={key}>
@@ -33,19 +33,23 @@ export default function TabbedCard({
           </React.Fragment>
         ))}
       </header>
-      <section className={`bg-white max-w-full border border-black border-t-0 p-4 overflow-y-auto`} style={{flex: "1 1 auto"}}>
-        {Array.from(children.entries()).map(([key, value]) => (
-          <div
-            key={key}
-            className={[
-              "h-min",
-              key !== displayChild ? "hidden" : ""
-            ].join(" ")}
-          >
-            {value}
-          </div>
-        ))}
+      <section className={`bg-white h-full border border-black flex flex-col border-t-0 p-4 overflow-y-auto`} style={{flex: "1 1 auto"}}>
+        <div className="my-auto">
+          {Array.from(children.entries()).map(([key, value]) => (
+            <div
+              key={key}
+              className={[
+                "",
+                key !== displayChild ? "hidden" : ""
+              ].join(" ")}
+              style={{flex: "0 0 auto"}}
+            >
+              {value}
+            </div>
+          ))}
+        </div>
       </section>
+      <div/>
     </article>
   );
 }

--- a/dapp/src/components/TabbedCard.tsx
+++ b/dapp/src/components/TabbedCard.tsx
@@ -4,9 +4,11 @@ import React, { useState } from "react";
 export default function TabbedCard({
   children,
   className = "",
+  containerClassName = "",
 }: {
   children: Map<string, any>;
   className?: string;
+  containerClassName?: string;
 }) {
   const [currentChild, setCurrentChild] = useState<string>(children.keys().next().value);
   let displayChild = currentChild;
@@ -34,7 +36,7 @@ export default function TabbedCard({
         ))}
       </header>
       <section className={`bg-white h-full border border-black flex flex-col border-t-0 p-4 overflow-y-auto`} style={{flex: "1 1 auto"}}>
-        <div className="my-auto">
+        <div className={containerClassName}>
           {Array.from(children.entries()).map(([key, value]) => (
             <div
               key={key}

--- a/dapp/src/components/TimeTravelWidget.tsx
+++ b/dapp/src/components/TimeTravelWidget.tsx
@@ -48,16 +48,17 @@ function queryBlockByNumber(client: ApolloClient<any>, block: string): Promise<A
 
 const timeTravelingNote = "You're currently viewing a past version of the board. The content is displayed as it was shown to users at the specified date.";
 
+// Block traveled to when time traveling
+// undefined when in present
 let setTraveledBlock: (b: Block | undefined) => void;
 export const useTraveledBlock = singletonHook<Block | undefined>(undefined, () => {
   let [block, setBlock] = useState<Block | undefined>();
-  setTraveledBlock = (b) => {
-    setBlock(b);
-    console.log(`traveled block set to ${JSON.stringify(b)}`);
-  }
+  setTraveledBlock = setBlock;
   return block;
 })
 
+// Block traveled to when time traveling
+// LastBlock when in present
 let setCurrentBlock: (b: Block | undefined) => void;
 const useCurrentBlock = singletonHook<Block | undefined>(undefined, () => {
   let [block, setBlock] = useState<Block | undefined>();
@@ -97,7 +98,7 @@ export default forwardRef(({
   const { lastBlock } = useLastBlock();
   const [timeTravelRange, setTimeTravelRange] = useState<TimeTravelRange>();
   const currentBlock = useCurrentBlock();
-  const _traveledBlock = useTraveledBlock();
+  useTraveledBlock();
   const [prevQueriedBlock, setPrevQueriedBlock] = useState<string | undefined>(block);
   const [timeTraveledToDate, setTimeTraveledToDate] = useState<DateTime | undefined>(dateTime);
   const [timeTraveledToNumber, setTimeTraveledToNumber] = useState<string | undefined>(block);
@@ -122,7 +123,7 @@ export default forwardRef(({
       //setTimeTraveledToNumber(`${block.number}`);
       setTimeTraveledToDate(DateTime.fromSeconds(parseInt(block.timestamp)));
     },
-    [setCurrentBlock, setTimeTraveledToDate]
+    [setTimeTraveledToDate]
   );
 
   const travelToLatest = useCallback(
@@ -199,7 +200,6 @@ export default forwardRef(({
     } else if (!block && lastBlock && currentBlock !== lastBlock) {
       // not time traveling
       // move traveledBlock forward to keep in sync with latest
-      console.log("trigger")
       travelToLatest();
     } else if (!currentBlock) {
       if (timeTraveledToDate != null) {

--- a/dapp/src/components/TimeTravelWidget.tsx
+++ b/dapp/src/components/TimeTravelWidget.tsx
@@ -277,7 +277,7 @@ export default forwardRef(({
       <summary className="list-none cursor-pointer w-full mx-1 whitespace-nowrap" onClick={(event) => {
         event.preventDefault();
       }}>
-        {timeTravelRange ? <>
+        {timeTravelRange && baseUrl ? <>
           <div className="ml-2 hidden sm:block">
             {isTimeTraveling ? <>
               <span title={timeTravelingNote} onClick={() => {
@@ -330,7 +330,7 @@ export default forwardRef(({
             )}
           </div>
         </> : (
-          ""
+          null
         )}
       </summary>
       <div className="absolute w-screen sm:w-max top-7 sm:top-full sm:mt-1 left-0 right-0 sm:left-auto sm:right-0">

--- a/dapp/src/components/TimeTravelWidget.tsx
+++ b/dapp/src/components/TimeTravelWidget.tsx
@@ -119,7 +119,9 @@ export default forwardRef(({
         const b = result.data?.blocks?.[0];
         if (b != null) {
           const url = !!baseUrl
-            ? `${baseUrl}?block=${b.number}`
+            ? baseUrl.includes("?")
+              ? `${baseUrl}&block=${block}`
+              : `${baseUrl}?block=${block}`
             : undefined;
 
           setWritingState(true);
@@ -138,7 +140,9 @@ export default forwardRef(({
     (block: string) => {
       const url = !!baseUrl
         ? !!block
-          ? `${baseUrl}?block=${block}`
+          ? baseUrl.includes("?")
+            ? `${baseUrl}&block=${block}`
+            : `${baseUrl}?block=${block}`
           : `${baseUrl}`
         : undefined;
 

--- a/dapp/src/components/TimeTravelWidget.tsx
+++ b/dapp/src/components/TimeTravelWidget.tsx
@@ -120,8 +120,8 @@ export default forwardRef(({
         if (b != null) {
           const url = !!baseUrl
             ? baseUrl.includes("?")
-              ? `${baseUrl}&block=${block}`
-              : `${baseUrl}?block=${block}`
+              ? `${baseUrl}&block=${b.number}`
+              : `${baseUrl}?block=${b.number}`
             : undefined;
 
           setWritingState(true);

--- a/dapp/src/components/WatchedThreadsCard.tsx
+++ b/dapp/src/components/WatchedThreadsCard.tsx
@@ -17,6 +17,7 @@ export default function WatchedThreadsCard({block} : {block?: number}) {
     block ? THREADS_LIST_FAVORITES_BLOCK : THREADS_LIST_FAVORITES,
     {
       pollInterval: 30_000,
+      fetchPolicy: block ? "cache-first" : "network-only",
       variables: {
         ids,
         block,

--- a/dapp/src/components/WatchedThreadsCard.tsx
+++ b/dapp/src/components/WatchedThreadsCard.tsx
@@ -2,7 +2,6 @@ import { useQuery } from "@apollo/react-hooks";
 import THREADS_LIST_FAVORITES from "graphql/queries/threads/list_favorites";
 import useFavorites from "hooks/useFavorites";
 import { useMemo } from "react";
-import Card from "./Card";
 import CatalogView from "./CatalogView";
 import Loading from "./Loading";
 
@@ -21,11 +20,9 @@ export default function WatchedThreadsCard() {
     skip: !favorites,
   });
   const threads = data?.threads
-  return loading || (threads && threads.length > 0) ?
-    <Card className="max-w-initial p-2 pt-4" title={<span>👁 Watched threads</span>}>
-      {loading ? <Loading /> : <CatalogView threads={threads || []} showBoard={true} />}
-    </Card>
-    : (
-      null
-    );
+  return loading || (threads && threads.length > 0)
+    ? loading
+      ? <Loading />
+      : <CatalogView threads={threads || []} showBoard={true} />
+    : null;
 }

--- a/dapp/src/components/WatchedThreadsCard.tsx
+++ b/dapp/src/components/WatchedThreadsCard.tsx
@@ -29,5 +29,5 @@ export default function WatchedThreadsCard({block} : {block?: number}) {
     ? loading
       ? <Loading />
       : <CatalogView threads={threads || []} showBoard={true} block={block} />
-    : null;
+    : <span>No threads are being watched. Use the 👁 button on threads to keep track of them here.</span>;
 }

--- a/dapp/src/components/WatchedThreadsCard.tsx
+++ b/dapp/src/components/WatchedThreadsCard.tsx
@@ -22,10 +22,10 @@ export default function WatchedThreadsCard() {
   });
   const threads = data?.threads
   return loading || (threads && threads.length > 0) ?
-    <Card className="w-100vw max-w-initial p-2 pt-4" title={<span>👁 Watched threads</span>}>
+    <Card className="max-w-initial p-2 pt-4" title={<span>👁 Watched threads</span>}>
       {loading ? <Loading /> : <CatalogView threads={threads || []} showBoard={true} />}
     </Card>
     : (
-      <span />
+      null
     );
 }

--- a/dapp/src/components/WatchedThreadsCard.tsx
+++ b/dapp/src/components/WatchedThreadsCard.tsx
@@ -1,28 +1,33 @@
 import { useQuery } from "@apollo/react-hooks";
 import THREADS_LIST_FAVORITES from "graphql/queries/threads/list_favorites";
+import THREADS_LIST_FAVORITES_BLOCK from "graphql/queries/threads/list_favorites_block";
 import useFavorites from "hooks/useFavorites";
 import { useMemo } from "react";
 import CatalogView from "./CatalogView";
 import Loading from "./Loading";
 
-export default function WatchedThreadsCard() {
+export default function WatchedThreadsCard({block} : {block?: number}) {
   const { favorites } = useFavorites();
   const ids = useMemo(
     () => (favorites ? Object.keys(favorites) : []),
     [favorites]
   );
 
-  const { data, loading } = useQuery(THREADS_LIST_FAVORITES, {
-    pollInterval: 30_000,
-    variables: {
-      ids,
-    },
-    skip: !favorites,
-  });
+  const { data, loading } = useQuery(
+    block ? THREADS_LIST_FAVORITES_BLOCK : THREADS_LIST_FAVORITES,
+    {
+      pollInterval: 30_000,
+      variables: {
+        ids,
+        block,
+      },
+      skip: !favorites,
+    }
+  );
   const threads = data?.threads
   return loading || (threads && threads.length > 0)
     ? loading
       ? <Loading />
-      : <CatalogView threads={threads || []} showBoard={true} />
+      : <CatalogView threads={threads || []} showBoard={true} block={block} />
     : null;
 }

--- a/dapp/src/components/WatchedThreadsWidget.tsx
+++ b/dapp/src/components/WatchedThreadsWidget.tsx
@@ -34,7 +34,7 @@ export default function WatchedThreadsWidget({ block }: { block?: string }) {
     <div className="text-center bg-primary border border-secondary-accent p-1">
       {loading ? (
         <Loading />
-      ) : ids.length > 0 && threads ? (
+      ) : ids.length > 0 && threads && threads.length > 0 ? (
         <div>
           <div className="mb-2">Watched threads:</div>
           <div className="text-sm">
@@ -81,7 +81,7 @@ export default function WatchedThreadsWidget({ block }: { block?: string }) {
           </div>
         </div>
       ) : (
-        "No posts are being watched. Use the 👁 button on threads to keep track of them here."
+        "No threads are being watched. Use the 👁 button on threads to keep track of them here."
       )}
     </div>
   ) : (

--- a/dapp/src/components/board/header.tsx
+++ b/dapp/src/components/board/header.tsx
@@ -62,7 +62,7 @@ export default function BoardHeader({
             {board === null ? (
               <div>/?/ - ?????</div>
             ) : (
-              <Link to={board ? `/${board.name}/${board.id}${search || ""}` : "#"}>
+              <Link to={board ? `/${board.name}/${board.id}${search || ""}${block ? `?block=${block}` : ""}` : "#"}>
                 /{board?.name || "?"}/ - {board?.title || "..."}
               </Link>
             )}

--- a/dapp/src/components/board/list.tsx
+++ b/dapp/src/components/board/list.tsx
@@ -3,7 +3,7 @@ import { Board } from "dchan";
 import IdLabel from "components/IdLabel";
 import Loading from "components/Loading";
 
-function BoardItem({ id, title, postCount, name, isLocked, isNsfw }: Board) {
+function BoardItem({ id, title, postCount, name, isLocked, isNsfw }: Board, block?: number) {
   return (
     <tr className="relative" key={id}>
       <td>
@@ -15,7 +15,7 @@ function BoardItem({ id, title, postCount, name, isLocked, isNsfw }: Board) {
         <span>
           <Link
             className="text-blue-600 visited:text-purple-600 hover:text-blue-500"
-            to={`/${name}/${id}`}
+            to={`/${name}/${id}${block ? `?block=${block}` : ""}`}
           >
             {title}
           </Link>
@@ -25,7 +25,7 @@ function BoardItem({ id, title, postCount, name, isLocked, isNsfw }: Board) {
         <span>
           <Link
             className="text-blue-600 visited:text-purple-600 hover:text-blue-500 mx-4"
-            to={`/${name}/${id}`}
+            to={`/${name}/${id}${block ? `?block=${block}` : ""}`}
           >
             /{name}/
           </Link>
@@ -54,16 +54,22 @@ export default function BoardList({
   className = "",
   loading = false,
   boards,
+  block
 }: {
   className?: string;
-  loading?: boolean,
+  loading?: boolean;
   boards?: Board[];
+  block?: number;
 }) {
   return (
     <div className={`${className} center`}>
       <table className="mx-8 border-separate" style={{borderSpacing: "0 0.25rem"}}>
         <tbody>
-          {loading? <Loading /> : !boards ? "" : boards.length > 0 ? boards.map(BoardItem) : "No boards"}
+          {loading
+            ? <Loading />
+            : !boards ? "" : boards.length > 0
+              ? boards.map(board => BoardItem(board, block))
+              : "No boards"}
         </tbody>
       </table>
     </div>

--- a/dapp/src/components/header/HeaderNavigation.tsx
+++ b/dapp/src/components/header/HeaderNavigation.tsx
@@ -25,6 +25,12 @@ enum OpenedWidgetEnum {
   SETTINGS = "SETTINGS",
 }
 
+const siteCreatedAtBlock: Block = {
+  id: "0x04eeaa77c96947c5efca4abd8e3f8de005369390409d79dfef81aa983eb69e89",
+  number: "17766365",
+  timestamp: "1628450632"
+};
+
 const SettingsWidgetOverlay = OverlayComponent(SettingsWidget);
 
 export default function HeaderNavigation({
@@ -51,7 +57,7 @@ export default function HeaderNavigation({
 
   useEffect(() => {
     setStartBlock(
-      thread ? thread.createdAtBlock : board ? board.createdAtBlock : undefined
+      thread ? thread.createdAtBlock : board ? board.createdAtBlock : siteCreatedAtBlock
     );
   }, [thread, board, setStartBlock]);
 
@@ -129,7 +135,7 @@ export default function HeaderNavigation({
               startBlock={startBlock}
               dateTime={dateTime}
               startRangeLabel={
-                thread ? "Thread creation" : board ? "Board creation" : "?"
+                thread ? "Thread creation" : board ? "Board creation" : "Site creation"
               }
             />
           )}</ApolloConsumer>

--- a/dapp/src/components/header/HeaderNavigation.tsx
+++ b/dapp/src/components/header/HeaderNavigation.tsx
@@ -110,7 +110,7 @@ export default function HeaderNavigation({
           [
           <Link
             className="text-blue-600 visited:text-purple-600 hover:text-blue-500"
-            to="/_/boards"
+            to={`${Router.boards()}${block ? `?block=${block}` : ""}`}
           >
             +
           </Link>
@@ -151,7 +151,7 @@ export default function HeaderNavigation({
               🔍
             </summary>
             <div className="absolute w-screen sm:w-max top-7 sm:top-full sm:mt-1 left-0 right-0 sm:left-auto sm:right-0">
-              <SearchWidget baseUrl={Router.posts()} search={search} />
+              <SearchWidget baseUrl={`${Router.posts()}${block ? `?block=${block}` : ""}`} search={search} />
             </div>
           </details>
           <details className="w-full sm:relative mx-1" open={openedWidget === OpenedWidgetEnum.WATCHEDTHREADS} ref={watchedThreadsRef}>

--- a/dapp/src/components/header/HeaderNavigation.tsx
+++ b/dapp/src/components/header/HeaderNavigation.tsx
@@ -90,7 +90,7 @@ export default function HeaderNavigation({
         [
         <Link
           className="text-blue-600 visited:text-purple-600 hover:text-blue-500"
-          to="/"
+          to={`/${block ? `?block=${block}` : ""}`}
         >
           dchan.network
         </Link>

--- a/dapp/src/components/header/generic.tsx
+++ b/dapp/src/components/header/generic.tsx
@@ -1,9 +1,10 @@
 import HeaderNavigation from "components/header/HeaderNavigation"
 import HeaderLogo from "components/header/logo"
+import { DateTime } from "luxon"
 
-const GenericHeader = ({title, block}: {title: string, block?: string}) => (
+const GenericHeader = ({title, baseUrl, block, dateTime}: {title: string, baseUrl?: string, block?: string, dateTime?: DateTime}) => (
     <header>
-        <HeaderNavigation block={block} />
+        <HeaderNavigation baseUrl={baseUrl} block={block} dateTime={dateTime} />
         <HeaderLogo />
 
         <div className="text-4xl text-contrast font-weight-800 font-family-tahoma">

--- a/dapp/src/components/post/Post.tsx
+++ b/dapp/src/components/post/Post.tsx
@@ -121,27 +121,43 @@ function Post({
     !bIsLowScore ||
     settings?.content_filter?.show_below_threshold ||
     showAnyway;
+  const toggleRef = useRef<HTMLDetailsElement>(null);
+  const [showBody, setShowBody] = useState<boolean>(canShow);
+  useEffect(() => {
+    if (toggleRef.current) {
+      setShowBody(toggleRef.current.open);
+    }
+  }, [toggleRef, setShowBody]);
 
   return (
-    <div className="flex">
+    <div className="flex relative">
       {!isOp ? <span className="hidden md:block pl-2 text-secondary">&gt;&gt;</span> : ""}
-      <details
-        className="dchan-post-expand mx-auto md:mr-3 md:ml-2 text-left inline"
-        open={canShow}
+      <div
+        className="mx-auto md:mr-3 md:ml-2 text-left inline"
         key={id}
         ref={postRef}
       >
-        <summary
-          className="text-left opacity-50 z-10 whitespace-nowrap overflow-hidden mb-1 flex center"
+        <details
+          className="absolute ml-2 -mt-0.5 z-10" 
+          ref={toggleRef}
+          open={canShow}
+          onToggle={(e: any) => {
+            setShowBody(e.target.open)
+          }}
+        >
+          <summary/>
+        </details>
+        <div
+          className={`text-left opacity-50 whitespace-nowrap mb-1 overflow-hidden flex ml-5 ${showBody ? "hidden" : ""}`}
           title="Hide/Show"
         >
           <PostHeader thread={thread} post={post} block={block}>
             {header}
           </PostHeader>
-        </summary>
-        <article
+        </div>
+        <div
           id={`${n}`}
-          className={`dchan-post text-left w-full`}
+          className={`dchan-post text-left w-full  ${!showBody ? "hidden" : ""}`}
           dchan-post-from-address={address}
         >
           <div
@@ -258,8 +274,8 @@ function Post({
               </div>
             )}
           </div>
-        </article>
-      </details>
+        </div>
+      </div>
     </div>
   );
 }

--- a/dapp/src/components/post/Post.tsx
+++ b/dapp/src/components/post/Post.tsx
@@ -145,7 +145,7 @@ function Post({
           dchan-post-from-address={address}
         >
           <div
-            className={`${isHighlighted || isFocused ? "bg-tertiary" : !isOp ? "bg-secondary" : ""} ${isYou ? "border-dashed border-2 border-tertiary" : ""} w-full sm:w-full mb-2 pr-4 inline-block relative`}
+            className={`${isHighlighted || isFocused ? "bg-tertiary" : !isOp ? "bg-secondary" : ""} ${isYou ? "border-dashed border-2 border-tertiary" : ""} w-full sm:w-full mb-2 inline-block relative`}
           >
             <div className="flex sm:flex-wrap ml-5 align-center text-center sm:text-left sm:justify-start max-w-100vw">
               <PostHeader thread={thread} post={post} backlinks={backlinks} block={block}>
@@ -250,7 +250,7 @@ function Post({
                   </div>
                   {children}
                   <Link
-                    className="px-1 text-xs opacity-10 hover:opacity-100 absolute bottom-0 right-0"
+                    className="px-1 text-xs opacity-10 hover:opacity-100 absolute bottom-0 right-0 hidden sm:inline"
                     to={`/${post.id}${block ? `?block=${block}` : ""}`} title="Permalink">
                     <small>{post.id}</small>
                   </Link>

--- a/dapp/src/components/post/PostBody.tsx
+++ b/dapp/src/components/post/PostBody.tsx
@@ -32,7 +32,7 @@ function Reference({link, children}: {link: string; children: string | string[]}
       to={link}
     >
       <wbr/>
-      <span className="whitespace-nowrap">&gt;&gt;{children}</span>
+      <span>&gt;&gt;{children}</span>
     </Link>
   );
 }

--- a/dapp/src/graphql/queries/boards/list_block.ts
+++ b/dapp/src/graphql/queries/boards/list_block.ts
@@ -1,0 +1,20 @@
+import { gql } from "apollo-boost";
+import BOARD_FRAGMENT from "graphql/fragments/board";
+
+const BOARDS_LIST_BLOCK = gql`
+  ${BOARD_FRAGMENT}
+  
+  query Boards($block: Int) {
+    mostPopular: boards(orderBy: postCount, orderDirection: desc, where: {score_gt: "900000000"}, block: {number: $block}) {
+      ...Board
+    }
+    lastBumped: boards(orderBy: lastBumpedAt, orderDirection: desc, where: {score_gt: "900000000"}, block: {number: $block}) {
+      ...Board
+    }
+    lastCreated: boards(orderBy: createdAt, orderDirection: desc, where: {score_gt: "900000000"}, block: {number: $block}) {
+      ...Board
+    }
+  }
+`;
+
+export default BOARDS_LIST_BLOCK;

--- a/dapp/src/graphql/queries/boards/list_most_popular_block.ts
+++ b/dapp/src/graphql/queries/boards/list_most_popular_block.ts
@@ -1,0 +1,20 @@
+import { gql } from "apollo-boost";
+
+const BOARDS_LIST_MOST_POPULAR_BLOCK = gql`
+  fragment Board on Board {
+    id
+    title
+    postCount
+    name
+    isLocked
+    isNsfw
+  }
+
+  query Boards($block: Int!) {
+    boards(orderBy: postCount, orderDirection: desc, first: 10, block: {number: $block}) {
+      ...Board
+    }
+  }
+`;
+
+export default BOARDS_LIST_MOST_POPULAR_BLOCK;

--- a/dapp/src/graphql/queries/boards/search_block.ts
+++ b/dapp/src/graphql/queries/boards/search_block.ts
@@ -1,0 +1,17 @@
+import { gql } from "apollo-boost";
+import BOARD_FRAGMENT from "graphql/fragments/board";
+
+const BOARDS_SEARCH = gql`
+  ${BOARD_FRAGMENT}
+
+  query BoardsSearch($searchName: String!, $searchTitle: String!, $block: Int) {
+    searchByTitle: boardSearch(text: $searchTitle, block: {number: $block}) {
+      ...Board
+    }
+    searchByName: boards(where: {name: $searchName}, block: {number: $block}) {
+      ...Board
+    }
+  }
+`;
+
+export default BOARDS_SEARCH;

--- a/dapp/src/graphql/queries/post_search_block.ts
+++ b/dapp/src/graphql/queries/post_search_block.ts
@@ -4,8 +4,8 @@ import POST_FRAGMENT from "../fragments/post";
 const POST_SEARCH = gql`
   ${POST_FRAGMENT}
   
-  query PostSearch($search: String!) {
-    postSearch(text: $search, orderBy: createdAt, orderDirection: desc) {
+  query PostSearch($search: String!, $block: Int!) {
+    postSearch(text: $search, orderBy: createdAt, orderDirection: desc, block: {number: $block}) {
       ...Post
     }
   }

--- a/dapp/src/graphql/queries/posts_get_last_block.ts
+++ b/dapp/src/graphql/queries/posts_get_last_block.ts
@@ -1,0 +1,14 @@
+import { gql } from "apollo-boost";
+import POST_FRAGMENT from "graphql/fragments/post";
+
+const POSTS_GET_LAST_BLOCK = gql`
+  ${POST_FRAGMENT}
+
+  query PostsGetLast($block: Int!) {
+    posts(orderBy: createdAt, orderDirection: desc, first: 50, where: {sage: false}, block: {number: $block}) {
+      ...Post
+    }
+  }
+`;
+
+export default POSTS_GET_LAST_BLOCK;

--- a/dapp/src/graphql/queries/threads/list_favorites.ts
+++ b/dapp/src/graphql/queries/threads/list_favorites.ts
@@ -7,7 +7,7 @@ const THREADS_LIST_FAVORITES = gql`
   query Threads($ids: [String!]!) {
     threads(orderBy: lastBumpedAt, orderDirection: desc, where: {id_in: $ids}) {
       ...Thread
-      replies(first: 3, orderBy: n, orderDirection: $orderDirection) {
+      replies(first: 3, orderBy: n, orderDirection: desc) {
         ...Post
       }
     }

--- a/dapp/src/graphql/queries/threads/list_favorites_block.ts
+++ b/dapp/src/graphql/queries/threads/list_favorites_block.ts
@@ -1,0 +1,17 @@
+import { gql } from "apollo-boost";
+import THREAD_FRAGMENT from "graphql/fragments/thread";
+
+const THREADS_LIST_FAVORITES_BLOCK = gql`
+  ${THREAD_FRAGMENT}
+
+  query Threads($ids: [String!]!, $block: Int!) {
+    threads(orderBy: lastBumpedAt, orderDirection: desc, where: {id_in: $ids}, block: {number: $block}) {
+      ...Thread
+      replies(first: 3, orderBy: n, orderDirection: desc) {
+        ...Post
+      }
+    }
+  }
+`;
+
+export default THREADS_LIST_FAVORITES_BLOCK;

--- a/dapp/src/graphql/queries/threads/list_most_popular_block.ts
+++ b/dapp/src/graphql/queries/threads/list_most_popular_block.ts
@@ -1,0 +1,14 @@
+import { gql } from "apollo-boost";
+import THREAD_FRAGMENT from "graphql/fragments/thread";
+
+const THREADS_LIST_MOST_POPULAR_BLOCK = gql`
+  ${THREAD_FRAGMENT}
+
+  query ThreadsListMostPopular($cutoff: Int!, $block: Int!) {
+    threads(orderBy: replyCount, orderDirection: desc, first: 10, where: {lastBumpedAt_gt: $cutoff}, block: {number: $block}) {
+      ...Thread
+    }
+  }
+`;
+
+export default THREADS_LIST_MOST_POPULAR_BLOCK;

--- a/dapp/src/pages/board.tsx
+++ b/dapp/src/pages/board.tsx
@@ -135,7 +135,7 @@ export default function BoardPage({ location, match: { params } }: any) {
   );
 
   return (
-    <div className="bg-primary min-h-100vh">
+    <div className="bg-primary min-h-100vh flex flex-col">
       <div>
         <ContentHeader
           board={board}
@@ -165,7 +165,7 @@ export default function BoardPage({ location, match: { params } }: any) {
               </> : ""}
             </div>
           ) : catalogLoading && !catalogData ? (
-            <div className="center grid min-h-50vh">
+            <div className="center grid">
               <Loading />
             </div>
           ) : board && threads ? (

--- a/dapp/src/pages/boardSearch.tsx
+++ b/dapp/src/pages/boardSearch.tsx
@@ -20,7 +20,7 @@ export default function BoardListPage({
   });
 
   return (
-    <div className="bg-primary min-h-100vh">
+    <div className="bg-primary min-h-100vh flex flex-col">
       <GenericHeader title="Boards" block={query.block ? `${query.block}` : undefined} />
 
       <Link

--- a/dapp/src/pages/boards.tsx
+++ b/dapp/src/pages/boards.tsx
@@ -7,6 +7,7 @@ import { useQuery } from "@apollo/react-hooks";
 import { Board } from "dchan";
 import BoardCreationForm from "components/BoardCreationForm";
 import SearchWidget from "components/SearchWidget";
+import TabbedCard from "components/TabbedCard";
 import { parse as parseQueryString } from "query-string";
 import { isString, uniqBy } from "lodash";
 import { Router } from "router";
@@ -111,26 +112,22 @@ export default function BoardListPage({ location, match: { params } }: any) {
               )}
             </div>
           </div>
-        ) : boardsData ? (
-          <div>
-            <div className="grid justify-center">
-              <Card title={<span>Most popular</span>} className="pt-4">
-                <BoardList boards={boardsData.mostPopular} block={queriedBlock} />
-              </Card>
-              <Card title={<span>Last created</span>} className="pt-4">
-                <BoardList boards={boardsData.lastCreated} block={queriedBlock} />
-              </Card>
-              <Card title={<span>Last bumped</span>} className="pt-4">
-                <BoardList boards={boardsData.lastBumped} block={queriedBlock} />
-              </Card>
-            </div>
-            <div className="center flex">
-              <div>
-                <BoardCreationForm />
-              </div>
+        ) : boardsData ? <>
+          <div className="flex flex-col justify-center">
+            <TabbedCard className="w-screen sm:w-auto mt-4 sm:mx-auto">
+              {new Map([
+                ["Most popular", <BoardList boards={boardsData.mostPopular} block={queriedBlock} />],
+                ["Last created", <BoardList boards={boardsData.lastCreated} block={queriedBlock} />],
+                ["Last bumped",  <BoardList boards={boardsData.lastBumped}  block={queriedBlock} />],
+              ])}
+            </TabbedCard>
+          </div>
+          <div className="center flex">
+            <div>
+              <BoardCreationForm />
             </div>
           </div>
-        ) : (
+        </> : (
           ""
         )}
       </div>

--- a/dapp/src/pages/boards.tsx
+++ b/dapp/src/pages/boards.tsx
@@ -74,13 +74,17 @@ export default function BoardListPage({ location, match: { params } }: any) {
     searchRefetch();
   }, [search, searchRefetch]);
 
+  useEffect(() => {
+    window.scrollTo({top: 0})
+  }, [search])
+
   const searchResults =
     searchData && (searchData.searchByTitle || searchData.searchByName)
       ? uniqBy([...searchData.searchByName, ...searchData.searchByTitle], "id")
       : [];
 
   return (
-    <div className="bg-primary min-h-100vh">
+    <div className="bg-primary min-h-100vh flex flex-col">
       <GenericHeader
         title="Boards"
         baseUrl={`${Router.boards()}${search ? `?s=${search}` : ""}`}
@@ -88,52 +92,50 @@ export default function BoardListPage({ location, match: { params } }: any) {
         dateTime={dateTime}
       />
       <div>
-        <div>
-          <div className="flex center">
-            <SearchWidget baseUrl={`${Router.boards()}${queriedBlock ? `?block=${queriedBlock}` : ""}`} search={search} />
-          </div>
-          {searchLoading || boardsLoading ? (
-            <div className="center grid">
-              <Loading></Loading>
-            </div>
-          ) : search ? (
-            <div className="center flex">
-              <div className="p-2">
-                {searchResults.length > 0 ? (
-                  <Card title={<span>Results for "{search}"</span>} className="pt-4">
-                    <BoardList boards={searchResults} block={queriedBlock} />
-                  </Card>
-                ) : (
-                  "No boards found"
-                )}
-              </div>
-            </div>
-          ) : boardsData ? (
-            <div>
-              <div className="grid justify-center">
-                <Card title={<span>Most popular</span>} className="pt-4">
-                  <BoardList boards={boardsData.mostPopular} block={queriedBlock} />
-                </Card>
-                <Card title={<span>Last created</span>} className="pt-4">
-                  <BoardList boards={boardsData.lastCreated} block={queriedBlock} />
-                </Card>
-                <Card title={<span>Last bumped</span>} className="pt-4">
-                  <BoardList boards={boardsData.lastBumped} block={queriedBlock} />
-                </Card>
-              </div>
-              <div className="center flex">
-                <div>
-                  <BoardCreationForm />
-                </div>
-              </div>
-            </div>
-          ) : (
-            ""
-          )}
+        <div className="flex center">
+          <SearchWidget baseUrl={`${Router.boards()}${queriedBlock ? `?block=${queriedBlock}` : ""}`} search={search} />
         </div>
-
-        <Footer />
+        {searchLoading || boardsLoading ? (
+          <div className="center grid">
+            <Loading></Loading>
+          </div>
+        ) : search ? (
+          <div className="center flex">
+            <div className="p-2">
+              {searchResults.length > 0 ? (
+                <Card title={<span>Results for "{search}"</span>} className="pt-4">
+                  <BoardList boards={searchResults} block={queriedBlock} />
+                </Card>
+              ) : (
+                "No boards found"
+              )}
+            </div>
+          </div>
+        ) : boardsData ? (
+          <div>
+            <div className="grid justify-center">
+              <Card title={<span>Most popular</span>} className="pt-4">
+                <BoardList boards={boardsData.mostPopular} block={queriedBlock} />
+              </Card>
+              <Card title={<span>Last created</span>} className="pt-4">
+                <BoardList boards={boardsData.lastCreated} block={queriedBlock} />
+              </Card>
+              <Card title={<span>Last bumped</span>} className="pt-4">
+                <BoardList boards={boardsData.lastBumped} block={queriedBlock} />
+              </Card>
+            </div>
+            <div className="center flex">
+              <div>
+                <BoardCreationForm />
+              </div>
+            </div>
+          </div>
+        ) : (
+          ""
+        )}
       </div>
+
+      <Footer />
     </div>
   );
 }

--- a/dapp/src/pages/boards.tsx
+++ b/dapp/src/pages/boards.tsx
@@ -3,8 +3,7 @@ import BoardList from "components/board/list";
 import GenericHeader from "components/header/generic";
 import Card from "components/Card";
 import Loading from "components/Loading";
-import BOARDS_LIST from "graphql/queries/boards/list";
-import { useQuery } from "@apollo/react-hooks";
+import { useQuery, WatchQueryFetchPolicy } from "@apollo/react-hooks";
 import { Board } from "dchan";
 import BoardCreationForm from "components/BoardCreationForm";
 import SearchWidget from "components/SearchWidget";
@@ -12,7 +11,11 @@ import { parse as parseQueryString } from "query-string";
 import { isString, uniqBy } from "lodash";
 import { Router } from "router";
 import { useEffect } from "react";
+import BOARDS_LIST from "graphql/queries/boards/list";
+import BOARDS_LIST_BLOCK from "graphql/queries/boards/list_block";
 import BOARDS_SEARCH from "graphql/queries/boards/search";
+import BOARDS_SEARCH_BLOCK from "graphql/queries/boards/search";
+import { DateTime } from "luxon";
 
 interface BoardSearchData {
   searchByName: Board[];
@@ -22,6 +25,7 @@ interface BoardSearchData {
 interface BoardSearchVars {
   searchName: string;
   searchTitle: string;
+  block?: number;
 }
 
 interface BoardListData {
@@ -36,16 +40,22 @@ export default function BoardListPage({ location, match: { params } }: any) {
   const query = parseQueryString(location.search);
   const search =
     `${params?.board_name || ""}` || (isString(query.s) ? query.s : "");
+    const block = parseInt(`${query.block}`);
+    const queriedBlock = isNaN(block) ? undefined : block;
+    const dateTime = query.date
+      ? DateTime.fromISO(query.date as string)
+      : undefined;
 
   const {
     refetch: searchRefetch,
     data: searchData,
     loading: searchLoading,
-  } = useQuery<BoardSearchData, BoardSearchVars>(BOARDS_SEARCH, {
+  } = useQuery<BoardSearchData, BoardSearchVars>(block ? BOARDS_SEARCH_BLOCK : BOARDS_SEARCH, {
     pollInterval: 30_000,
     variables: {
       searchName: search,
       searchTitle: search.length > 1 ? `${search}:*` : "",
+      block: queriedBlock,
     },
     skip: !search,
   });
@@ -53,8 +63,9 @@ export default function BoardListPage({ location, match: { params } }: any) {
   const { data: boardsData, loading: boardsLoading } = useQuery<
     BoardListData,
     BoardListVars
-  >(BOARDS_LIST, {
+  >(block ? BOARDS_LIST_BLOCK : BOARDS_LIST, {
     pollInterval: 30_000,
+    variables: {block: queriedBlock}
   });
 
   useEffect(() => {
@@ -68,7 +79,12 @@ export default function BoardListPage({ location, match: { params } }: any) {
 
   return (
     <div className="bg-primary min-h-100vh">
-      <GenericHeader title="Boards" block={query.block ? `${query.block}` : undefined} />
+      <GenericHeader
+        title="Boards"
+        baseUrl="/_/boards"
+        block={queriedBlock ? `${queriedBlock}` : undefined}
+        dateTime={dateTime}
+      />
       <div>
         <div>
           <div className="flex center">

--- a/dapp/src/pages/boards.tsx
+++ b/dapp/src/pages/boards.tsx
@@ -81,14 +81,14 @@ export default function BoardListPage({ location, match: { params } }: any) {
     <div className="bg-primary min-h-100vh">
       <GenericHeader
         title="Boards"
-        baseUrl="/_/boards"
+        baseUrl={`${Router.boards()}${search ? `?s=${search}` : ""}`}
         block={queriedBlock ? `${queriedBlock}` : undefined}
         dateTime={dateTime}
       />
       <div>
         <div>
           <div className="flex center">
-            <SearchWidget baseUrl={Router.boards()} search={search} />
+            <SearchWidget baseUrl={`${Router.boards()}${queriedBlock ? `?block=${queriedBlock}` : ""}`} search={search} />
           </div>
           {searchLoading || boardsLoading ? (
             <div className="center grid">
@@ -99,7 +99,7 @@ export default function BoardListPage({ location, match: { params } }: any) {
               <div className="p-2">
                 {searchResults.length > 0 ? (
                   <Card title={<span>Results for "{search}"</span>} className="pt-4">
-                    <BoardList boards={searchResults} />
+                    <BoardList boards={searchResults} block={queriedBlock} />
                   </Card>
                 ) : (
                   "No boards found"
@@ -110,13 +110,13 @@ export default function BoardListPage({ location, match: { params } }: any) {
             <div>
               <div className="grid justify-center">
                 <Card title={<span>Most popular</span>} className="pt-4">
-                  <BoardList boards={boardsData.mostPopular} />
+                  <BoardList boards={boardsData.mostPopular} block={queriedBlock} />
                 </Card>
                 <Card title={<span>Last created</span>} className="pt-4">
-                  <BoardList boards={boardsData.lastCreated} />
+                  <BoardList boards={boardsData.lastCreated} block={queriedBlock} />
                 </Card>
                 <Card title={<span>Last bumped</span>} className="pt-4">
-                  <BoardList boards={boardsData.lastBumped} />
+                  <BoardList boards={boardsData.lastBumped} block={queriedBlock} />
                 </Card>
               </div>
               <div className="center flex">

--- a/dapp/src/pages/boards.tsx
+++ b/dapp/src/pages/boards.tsx
@@ -52,6 +52,7 @@ export default function BoardListPage({ location, match: { params } }: any) {
     loading: searchLoading,
   } = useQuery<BoardSearchData, BoardSearchVars>(block ? BOARDS_SEARCH_BLOCK : BOARDS_SEARCH, {
     pollInterval: 30_000,
+    fetchPolicy: queriedBlock ? "cache-first" : "network-only",
     variables: {
       searchName: search,
       searchTitle: search.length > 1 ? `${search}:*` : "",
@@ -65,6 +66,7 @@ export default function BoardListPage({ location, match: { params } }: any) {
     BoardListVars
   >(block ? BOARDS_LIST_BLOCK : BOARDS_LIST, {
     pollInterval: 30_000,
+    fetchPolicy: queriedBlock ? "cache-first" : "network-only",
     variables: {block: queriedBlock}
   });
 

--- a/dapp/src/pages/boards.tsx
+++ b/dapp/src/pages/boards.tsx
@@ -3,7 +3,7 @@ import BoardList from "components/board/list";
 import GenericHeader from "components/header/generic";
 import Card from "components/Card";
 import Loading from "components/Loading";
-import { useQuery, WatchQueryFetchPolicy } from "@apollo/react-hooks";
+import { useQuery } from "@apollo/react-hooks";
 import { Board } from "dchan";
 import BoardCreationForm from "components/BoardCreationForm";
 import SearchWidget from "components/SearchWidget";

--- a/dapp/src/pages/home.tsx
+++ b/dapp/src/pages/home.tsx
@@ -1,16 +1,14 @@
-import logo from "assets/images/dchan.png";
-import TabbedCard from "components/TabbedCard";
+import Card from "components/Card";
 import Footer from "components/Footer";
 import HeaderNavigation from "components/header/HeaderNavigation";
 import LatestPostsCard from "components/LatestPostsCard";
-import PopularBoardsCard from "components/PopularBoardsCard";
 import PopularThreadsCard from "components/PopularThreadsCard";
 import WatchedThreadsCard from "components/WatchedThreadsCard";
 import { parse as parseQueryString } from "query-string";
 import { DateTime } from "luxon";
 import { useEffect } from "react";
 import { useTitle } from "react-use";
-import { Polygon, TheGraph } from "components/FAQCard";
+import HeaderLogo from "components/header/logo";
 
 export default function HomePage({ location }: any) {
   useTitle("dchan.network");
@@ -33,49 +31,19 @@ export default function HomePage({ location }: any) {
         block={queriedBlock ? `${queriedBlock}` : undefined}
         dateTime={dateTime}
       />
-      <div className="lg:h-full max-w-full flex flex-col lg:flex-row pt-8" style={{flex: "1 0 auto", paddingBottom: "68.8px"}}>
-        <div className="lg:my-auto lg:w-1/2 lg:float-left px-8 pb-8">
-          <div className="mb-7">
-            <img
-              className="animation-spin w-48 pointer-events-none mx-auto"
-              src={logo}
-              alt="dchan"
-            />
-            <div className="font-mono text-4xl">dchan.network</div>
-          </div>
-          <div className="px-8 mx-auto">
-            Welcome to dchan.network, a decentralized time-traveling imageboard made entirely
-            using <TheGraph/> and <Polygon/>.
-            <br/>
-            Use with{" "}
-            <a
-              className="text-blue-600 visited:text-purple-600 hover:text-blue-500"
-              href="//metamask.io"
-            >
-              Metamask
-            </a>{" "}
-            (Desktop) or{" "}
-            <a
-              className="text-blue-600 visited:text-purple-600 hover:text-blue-500"
-              href="//trustwallet.com/"
-            >
-              Trust Wallet
-            </a>{" "}
-            (Mobile).
-          </div>
-        </div>
-        <div className="lg:h-full lg:w-1/2 lg:float-left flex flex-col lg:px-8 lg:pb-6">
-          <TabbedCard className="h-full flex flex-col" containerClassName="my-auto">
-            {new Map([
-              ["Popular Boards", <PopularBoardsCard block={queriedBlock} />],
-              ["Watched Threads", <WatchedThreadsCard block={queriedBlock} />],
-              ["Popular Threads", <PopularThreadsCard block={queriedBlock} />],
-              ["Latest Posts", <LatestPostsCard block={queriedBlock} />],
-            ])}
-          </TabbedCard>
-        </div>
+      <HeaderLogo/>
+      <div className="flex flex-row px-4">
+        <Card title={<span>Watched Threads</span>} className="w-1/2 pr-2 pb-4">
+          <WatchedThreadsCard block={queriedBlock} />
+        </Card>
+        <Card title={<span>Popular Threads</span>} className="w-1/2 pl-2 pb-4">
+          <PopularThreadsCard block={queriedBlock} />
+        </Card>
       </div>
-      <Footer className="mt-auto lg:mt-0 lg:fixed lg:bottom-0 lg:left-0 lg:right-0"/>
+      <Card title={<span>Latest Posts</span>} className="w-full px-4 pb-4">
+        <LatestPostsCard block={queriedBlock} />
+      </Card>
+      <Footer/>
     </div>
   );
 }

--- a/dapp/src/pages/home.tsx
+++ b/dapp/src/pages/home.tsx
@@ -24,61 +24,67 @@ export default function HomePage({ location }: any) {
   }, [])
 
   return (
-    <div className="center-grid max-w-full min-h-screen bg-primary pt-8">
+    <div className="center-grid max-w-full min-h-screen bg-primary pt-8 flex flex-col">
       <HeaderNavigation
         baseUrl="/"
         block={`${query.block}`}
         dateTime={dateTime}
       />
-      <div className="flex flex-wrap center">
-        <Card
-          title={
-            <a className="color-black" href="/">
-              dchan.network
-            </a>
-          }
-        >
-          <div>
-            <div className="p-4 center">
+      <div className="h-full w-screen flex flex-col lg:flex-row">
+        <div className="lg:h-full lg:w-1/2 lg:float-left">
+          <div className="center">
+            <div className="mb-7">
               <img
-                className="animation-spin p-2 w-auto pointer-events-none"
+                className="animation-spin w-48 pointer-events-none mx-auto"
                 src={logo}
                 alt="dchan"
               />
+              <div className="font-mono text-4xl">dchan.network</div>
             </div>
-            <div className="p-1 text-center">
-              <small>
-                Use with{" "}
-                <a
-                  className="text-blue-600 visited:text-purple-600 hover:text-blue-500"
-                  href="//metamask.io"
-                >
-                  Metamask
-                </a>{" "}
-                (Desktop) or{" "}
-                <a
-                  className="text-blue-600 visited:text-purple-600 hover:text-blue-500"
-                  href="//trustwallet.com/"
-                >
-                  Trust Wallet
-                </a>{" "}
-                (Mobile)
-              </small>
+            <div className="px-8 mx-auto">
+              Welcome to dchan.network, a decentralized, time-traveling imageboard made entirely
+              with The Graph (ticker: GRT) and Polygon.
+              <br/>
+              Use with{" "}
+              <a
+                className="text-blue-600 visited:text-purple-600 hover:text-blue-500"
+                href="//metamask.io"
+              >
+                Metamask
+              </a>{" "}
+              (Desktop) or{" "}
+              <a
+                className="text-blue-600 visited:text-purple-600 hover:text-blue-500"
+                href="//trustwallet.com/"
+              >
+                Trust Wallet
+              </a>{" "}
+              (Mobile).
+              <br/>
+              <span className="font-bold text-contrast">ADD BETTER BLURB TEXT HERE</span>
             </div>
           </div>
-        </Card>
-
-        <div className="grid center">
-          <PopularBoardsCard />
+        </div>
+        <div className="lg:h-full lg:w-1/2 lg:float-left">
+          <article className="max-h-full max-w-100vw mr-3">
+            <header className="bg-white border border-black flex flex-row justify-evenly">
+              <div className="bg-highlight opacity-80 hover:opacity-100 py-1 px-4 w-full font-bold">Popular Boards</div>
+              <div className="border-l border-black"/>
+              <div className="bg-highlight opacity-80 hover:opacity-100 py-1 px-4 w-full font-bold">Watched Threads</div>
+              <div className="border-l border-black"/>
+              <div className="bg-highlight opacity-80 hover:opacity-100 py-1 px-4 w-full font-bold">Popular Threads</div>
+              <div className="border-l border-black"/>
+              <div className="bg-highlight opacity-80 hover:opacity-100 py-1 px-4 w-full font-bold">Latest Posts</div>
+            </header>
+            <section className={`bg-white border border-black border-t-0 w-full p-4`} style={{flex: "1 1 auto"}}>
+              <PopularBoardsCard />
+              <WatchedThreadsCard />
+              <PopularThreadsCard /> 
+              <LatestPostsCard />
+            </section>
+          </article>
         </div>
       </div>
-        
-      <WatchedThreadsCard />
-
-      <PopularThreadsCard />
-      
-      <LatestPostsCard />
-
       <Footer />
     </div>
   );

--- a/dapp/src/pages/home.tsx
+++ b/dapp/src/pages/home.tsx
@@ -44,7 +44,7 @@ export default function HomePage({ location }: any) {
             <div className="font-mono text-4xl">dchan.network</div>
           </div>
           <div className="px-8 mx-auto">
-            Welcome to dchan.network, a decentralized, time-traveling imageboard made entirely
+            Welcome to dchan.network, a decentralized time-traveling imageboard made entirely
             using <TheGraph/> and <Polygon/>.
             <br/>
             Use with{" "}

--- a/dapp/src/pages/home.tsx
+++ b/dapp/src/pages/home.tsx
@@ -10,6 +10,8 @@ import { parse as parseQueryString } from "query-string";
 import { DateTime } from "luxon";
 import { useEffect } from "react";
 import { useTitle } from "react-use";
+import Card from "components/Card";
+import { Polygon, TheGraph } from "components/FAQCard";
 
 export default function HomePage({ location }: any) {
   useTitle("dchan.network");
@@ -26,14 +28,14 @@ export default function HomePage({ location }: any) {
   }, [])
 
   return (
-    <div className="h-full min-h-screen bg-primary pt-8 flex flex-col">
+    <div className="h-screen bg-primary flex flex-col pb-8">
       <HeaderNavigation
         baseUrl="/"
         block={queriedBlock ? `${queriedBlock}` : undefined}
         dateTime={dateTime}
       />
-      <div className="h-full max-w-full flex flex-col lg:flex-row" style={{flex: "1 1 auto"}}>
-        <div className="lg:h-full lg:w-1/2 lg:float-left lg:my-auto px-8">
+      <div className="lg:h-full max-w-full flex flex-col lg:flex-row pt-8" style={{flex: "1 1 auto", paddingBottom: "68.8px"}}>
+        <div className="lg:my-auto lg:w-1/2 lg:float-left px-8 pb-8">
           <div className="mb-7">
             <img
               className="animation-spin w-48 pointer-events-none mx-auto"
@@ -44,7 +46,7 @@ export default function HomePage({ location }: any) {
           </div>
           <div className="px-8 mx-auto">
             Welcome to dchan.network, a decentralized, time-traveling imageboard made entirely
-            using The Graph (ticker: GRT) and Polygon.
+            using <TheGraph/> and <Polygon/>.
             <br/>
             Use with{" "}
             <a
@@ -61,12 +63,10 @@ export default function HomePage({ location }: any) {
               Trust Wallet
             </a>{" "}
             (Mobile).
-            <br/>
-            <span className="font-bold text-contrast">ADD BETTER BLURB TEXT HERE</span>
           </div>
         </div>
-        <div className="lg:max-h-full lg:w-1/2 lg:float-left lg:px-8">
-          <TabbedCard className="mt-8 lg:mt-0 h-full">
+        <div className="lg:h-full lg:w-1/2 lg:float-left flex flex-col lg:px-8">
+          <TabbedCard className="h-full flex flex-col">
             {new Map([
               ["Popular Boards", <PopularBoardsCard block={queriedBlock} />],
               ["Watched Threads", <WatchedThreadsCard block={queriedBlock} />],
@@ -76,7 +76,7 @@ export default function HomePage({ location }: any) {
           </TabbedCard>
         </div>
       </div>
-      <Footer />
+      <Footer className="mt-auto lg:mt-0 lg:fixed lg:bottom-0 lg:left-0 lg:right-0"/>
     </div>
   );
 }

--- a/dapp/src/pages/home.tsx
+++ b/dapp/src/pages/home.tsx
@@ -15,6 +15,8 @@ export default function HomePage({ location }: any) {
   useTitle("dchan.network");
   
   const query = parseQueryString(location.search);
+  const block = parseInt(`${query.block}`);
+  const queriedBlock = isNaN(block) ? undefined : block;
   const dateTime = query.date
     ? DateTime.fromISO(query.date as string)
     : undefined;
@@ -27,7 +29,7 @@ export default function HomePage({ location }: any) {
     <div className="h-full min-h-screen bg-primary pt-8 flex flex-col">
       <HeaderNavigation
         baseUrl="/"
-        block={`${query.block}`}
+        block={queriedBlock ? `${queriedBlock}` : undefined}
         dateTime={dateTime}
       />
       <div className="h-full max-w-full flex flex-col lg:flex-row" style={{flex: "1 1 auto"}}>
@@ -66,10 +68,10 @@ export default function HomePage({ location }: any) {
         <div className="lg:max-h-full lg:w-1/2 lg:float-left lg:px-8">
           <TabbedCard className="mt-8 lg:mt-0 h-full">
             {new Map([
-              ["Popular Boards", <PopularBoardsCard/>],
-              ["Watched Threads", <WatchedThreadsCard/>],
-              ["Popular Threads", <PopularThreadsCard/>],
-              ["Latest Posts", <LatestPostsCard/>],
+              ["Popular Boards", <PopularBoardsCard block={queriedBlock} />],
+              ["Watched Threads", <WatchedThreadsCard block={queriedBlock} />],
+              ["Popular Threads", <PopularThreadsCard block={queriedBlock} />],
+              ["Latest Posts", <LatestPostsCard block={queriedBlock} />],
             ])}
           </TabbedCard>
         </div>

--- a/dapp/src/pages/home.tsx
+++ b/dapp/src/pages/home.tsx
@@ -32,11 +32,11 @@ export default function HomePage({ location }: any) {
         dateTime={dateTime}
       />
       <HeaderLogo/>
-      <div className="flex flex-row px-4">
-        <Card title={<span>Watched Threads</span>} className="w-1/2 pr-2 pb-4">
+      <div className="flex flex-col md:flex-row px-4">
+        <Card title={<span>Watched Threads</span>} className="md:w-1/2 md:pr-2 w-full pb-4">
           <WatchedThreadsCard block={queriedBlock} />
         </Card>
-        <Card title={<span>Popular Threads</span>} className="w-1/2 pl-2 pb-4">
+        <Card title={<span>Popular Threads</span>} className="md:w-1/2 md:pr-2 w-full pb-4">
           <PopularThreadsCard block={queriedBlock} />
         </Card>
       </div>

--- a/dapp/src/pages/home.tsx
+++ b/dapp/src/pages/home.tsx
@@ -1,5 +1,5 @@
 import logo from "assets/images/dchan.png";
-import Card from "components/Card";
+import TabbedCard from "components/TabbedCard";
 import Footer from "components/Footer";
 import HeaderNavigation from "components/header/HeaderNavigation";
 import LatestPostsCard from "components/LatestPostsCard";
@@ -24,65 +24,54 @@ export default function HomePage({ location }: any) {
   }, [])
 
   return (
-    <div className="center-grid max-w-full min-h-screen bg-primary pt-8 flex flex-col">
+    <div className="h-full min-h-screen bg-primary pt-8 flex flex-col">
       <HeaderNavigation
         baseUrl="/"
         block={`${query.block}`}
         dateTime={dateTime}
       />
-      <div className="h-full w-screen flex flex-col lg:flex-row">
-        <div className="lg:h-full lg:w-1/2 lg:float-left">
-          <div className="center">
-            <div className="mb-7">
-              <img
-                className="animation-spin w-48 pointer-events-none mx-auto"
-                src={logo}
-                alt="dchan"
-              />
-              <div className="font-mono text-4xl">dchan.network</div>
-            </div>
-            <div className="px-8 mx-auto">
-              Welcome to dchan.network, a decentralized, time-traveling imageboard made entirely
-              with The Graph (ticker: GRT) and Polygon.
-              <br/>
-              Use with{" "}
-              <a
-                className="text-blue-600 visited:text-purple-600 hover:text-blue-500"
-                href="//metamask.io"
-              >
-                Metamask
-              </a>{" "}
-              (Desktop) or{" "}
-              <a
-                className="text-blue-600 visited:text-purple-600 hover:text-blue-500"
-                href="//trustwallet.com/"
-              >
-                Trust Wallet
-              </a>{" "}
-              (Mobile).
-              <br/>
-              <span className="font-bold text-contrast">ADD BETTER BLURB TEXT HERE</span>
-            </div>
+      <div className="h-full max-w-full flex flex-col lg:flex-row" style={{flex: "1 1 auto"}}>
+        <div className="lg:h-full lg:w-1/2 lg:float-left lg:my-auto px-8">
+          <div className="mb-7">
+            <img
+              className="animation-spin w-48 pointer-events-none mx-auto"
+              src={logo}
+              alt="dchan"
+            />
+            <div className="font-mono text-4xl">dchan.network</div>
+          </div>
+          <div className="px-8 mx-auto">
+            Welcome to dchan.network, a decentralized, time-traveling imageboard made entirely
+            using The Graph (ticker: GRT) and Polygon.
+            <br/>
+            Use with{" "}
+            <a
+              className="text-blue-600 visited:text-purple-600 hover:text-blue-500"
+              href="//metamask.io"
+            >
+              Metamask
+            </a>{" "}
+            (Desktop) or{" "}
+            <a
+              className="text-blue-600 visited:text-purple-600 hover:text-blue-500"
+              href="//trustwallet.com/"
+            >
+              Trust Wallet
+            </a>{" "}
+            (Mobile).
+            <br/>
+            <span className="font-bold text-contrast">ADD BETTER BLURB TEXT HERE</span>
           </div>
         </div>
-        <div className="lg:h-full lg:w-1/2 lg:float-left">
-          <article className="max-h-full max-w-100vw mr-3">
-            <header className="bg-white border border-black flex flex-row justify-evenly">
-              <div className="bg-highlight opacity-80 hover:opacity-100 py-1 px-4 w-full font-bold">Popular Boards</div>
-              <div className="border-l border-black"/>
-              <div className="bg-highlight opacity-80 hover:opacity-100 py-1 px-4 w-full font-bold">Watched Threads</div>
-              <div className="border-l border-black"/>
-              <div className="bg-highlight opacity-80 hover:opacity-100 py-1 px-4 w-full font-bold">Popular Threads</div>
-              <div className="border-l border-black"/>
-              <div className="bg-highlight opacity-80 hover:opacity-100 py-1 px-4 w-full font-bold">Latest Posts</div>
-            </header>
-            <section className={`bg-white border border-black border-t-0 w-full p-4`} style={{flex: "1 1 auto"}}>
-              <PopularBoardsCard />
-              <WatchedThreadsCard />
-              <PopularThreadsCard /> 
-              <LatestPostsCard />
-            </section>
-          </article>
+        <div className="lg:max-h-full lg:w-1/2 lg:float-left lg:px-8">
+          <TabbedCard className="mt-8 lg:mt-0 h-full">
+            {new Map([
+              ["Popular Boards", <PopularBoardsCard/>],
+              ["Watched Threads", <WatchedThreadsCard/>],
+              ["Popular Threads", <PopularThreadsCard/>],
+              ["Latest Posts", <LatestPostsCard/>],
+            ])}
+          </TabbedCard>
         </div>
       </div>
       <Footer />

--- a/dapp/src/pages/home.tsx
+++ b/dapp/src/pages/home.tsx
@@ -33,7 +33,7 @@ export default function HomePage({ location }: any) {
         block={queriedBlock ? `${queriedBlock}` : undefined}
         dateTime={dateTime}
       />
-      <div className="lg:h-full max-w-full flex flex-col lg:flex-row pt-8" style={{flex: "1 1 auto", paddingBottom: "68.8px"}}>
+      <div className="lg:h-full max-w-full flex flex-col lg:flex-row pt-8" style={{flex: "1 0 auto", paddingBottom: "68.8px"}}>
         <div className="lg:my-auto lg:w-1/2 lg:float-left px-8 pb-8">
           <div className="mb-7">
             <img
@@ -64,7 +64,7 @@ export default function HomePage({ location }: any) {
             (Mobile).
           </div>
         </div>
-        <div className="lg:h-full lg:w-1/2 lg:float-left flex flex-col lg:px-8">
+        <div className="lg:h-full lg:w-1/2 lg:float-left flex flex-col lg:px-8 lg:pb-6">
           <TabbedCard className="h-full flex flex-col">
             {new Map([
               ["Popular Boards", <PopularBoardsCard block={queriedBlock} />],

--- a/dapp/src/pages/home.tsx
+++ b/dapp/src/pages/home.tsx
@@ -65,7 +65,7 @@ export default function HomePage({ location }: any) {
           </div>
         </div>
         <div className="lg:h-full lg:w-1/2 lg:float-left flex flex-col lg:px-8 lg:pb-6">
-          <TabbedCard className="h-full flex flex-col">
+          <TabbedCard className="h-full flex flex-col" containerClassName="my-auto">
             {new Map([
               ["Popular Boards", <PopularBoardsCard block={queriedBlock} />],
               ["Watched Threads", <WatchedThreadsCard block={queriedBlock} />],

--- a/dapp/src/pages/home.tsx
+++ b/dapp/src/pages/home.tsx
@@ -10,7 +10,6 @@ import { parse as parseQueryString } from "query-string";
 import { DateTime } from "luxon";
 import { useEffect } from "react";
 import { useTitle } from "react-use";
-import Card from "components/Card";
 import { Polygon, TheGraph } from "components/FAQCard";
 
 export default function HomePage({ location }: any) {

--- a/dapp/src/pages/home.tsx
+++ b/dapp/src/pages/home.tsx
@@ -1,15 +1,23 @@
 import logo from "assets/images/dchan.png";
 import Card from "components/Card";
 import Footer from "components/Footer";
+import HeaderNavigation from "components/header/HeaderNavigation";
 import LatestPostsCard from "components/LatestPostsCard";
 import PopularBoardsCard from "components/PopularBoardsCard";
 import PopularThreadsCard from "components/PopularThreadsCard";
 import WatchedThreadsCard from "components/WatchedThreadsCard";
+import { parse as parseQueryString } from "query-string";
+import { DateTime } from "luxon";
 import { useEffect } from "react";
 import { useTitle } from "react-use";
 
-export default function HomePage() {
+export default function HomePage({ location }: any) {
   useTitle("dchan.network");
+  
+  const query = parseQueryString(location.search);
+  const dateTime = query.date
+    ? DateTime.fromISO(query.date as string)
+    : undefined;
 
   useEffect(() => {
     window.scrollTo({top: 0})
@@ -17,6 +25,11 @@ export default function HomePage() {
 
   return (
     <div className="center-grid max-w-full min-h-screen bg-primary pt-8">
+      <HeaderNavigation
+        baseUrl="/"
+        block={`${query.block}`}
+        dateTime={dateTime}
+      />
       <div className="flex flex-wrap center">
         <Card
           title={

--- a/dapp/src/pages/postSearch.tsx
+++ b/dapp/src/pages/postSearch.tsx
@@ -71,7 +71,7 @@ export default function PostSearchPage({ location, match: { params } }: any) {
   }, [search, block, refetch]);
 
   return (
-    <div className="bg-primary min-h-100vh" data-theme={"blueboard"}>
+    <div className="bg-primary min-h-100vh flex flex-col" data-theme={"blueboard"}>
       <ContentHeader
         dateTime={dateTime}
         search={search}

--- a/dapp/src/pages/postSearch.tsx
+++ b/dapp/src/pages/postSearch.tsx
@@ -9,6 +9,7 @@ import { useQuery } from "@apollo/react-hooks";
 import { useEffect, useMemo } from "react";
 import { isLowScore, sortByCreatedAt } from "dchan/entities/post";
 import POST_SEARCH from "graphql/queries/post_search";
+import POST_SEARCH_BLOCK from "graphql/queries/post_search_block";
 import { Post } from "dchan";
 import PostComponent from "components/post/Post";
 import { Link } from "react-router-dom";
@@ -29,13 +30,11 @@ export default function PostSearchPage({ location, match: { params } }: any) {
   const s = query.s || query.search;
   const search = isString(s) ? s : "";
 
-  const { lastBlock } = useLastBlock();
-
+  const block = parseInt(`${query.block}`);
+  const queriedBlock = isNaN(block) ? undefined : `${block}`;
   const dateTime = query.date
     ? DateTime.fromISO(query.date as string)
     : undefined;
-  const block = parseInt(`${query.block || lastBlock?.number || ""}`);
-  const isTimeTraveling = query.block && `${query.block}` !== lastBlock?.number;
   const [settings] = useSettings();
 
   const variables = {
@@ -44,7 +43,7 @@ export default function PostSearchPage({ location, match: { params } }: any) {
   };
 
   const { refetch, data, loading } = useQuery<SearchData, SearchVars>(
-    POST_SEARCH,
+    block ? POST_SEARCH_BLOCK : POST_SEARCH,
     {
       variables,
       pollInterval: 60_000,
@@ -76,8 +75,8 @@ export default function PostSearchPage({ location, match: { params } }: any) {
       <ContentHeader
         dateTime={dateTime}
         search={search}
-        baseUrl={Router.posts()}
-        block={isTimeTraveling ? `${block}` : undefined}
+        baseUrl={`${Router.posts()}${search ? `?s=${search}` : ""}`}
+        block={queriedBlock}
         summary={
           results ? (
             <span>
@@ -109,7 +108,7 @@ export default function PostSearchPage({ location, match: { params } }: any) {
                   <PostComponent
                     key={post.id}
                     post={post}
-                    block={isTimeTraveling ? `${block}` : undefined}
+                    block={queriedBlock}
                     header={
                       <span>
                         <span className="p-1">

--- a/dapp/src/pages/postSearch.tsx
+++ b/dapp/src/pages/postSearch.tsx
@@ -1,5 +1,4 @@
 import Footer from "components/Footer";
-import useLastBlock from "hooks/useLastBlock";
 import { parse as parseQueryString } from "query-string";
 import { isString } from "lodash";
 import { DateTime } from "luxon";

--- a/dapp/src/pages/thread.tsx
+++ b/dapp/src/pages/thread.tsx
@@ -125,7 +125,7 @@ export default function ThreadPage({ location, match: { params } }: any) {
   );
 
   return (
-    <div className="bg-primary min-h-100vh">
+    <div className="bg-primary min-h-100vh flex flex-col">
       <ContentHeader
         board={board}
         thread={thread}


### PR DESCRIPTION
- [Homepage redone, no longer a mess of random boxes](https://i.imgur.com/x4vukh9.png)
- Time travel now supported on every page
- Relative time in posts is now relative to the time travelled to
  - Why not lol
- Footer now stays at the bottom of the page or lower
- Refactored post collapsing

Shit to do:
- Clicking on latest posts on the homepage within a certain timeframe causes the page to hang until the posts load
- Some caching issues were found in the boards lists when returning to present from time travel, causing the time travel post counts to be used instead of present ones
  - Current fix is to just have useQuery ignore cache when not time traveling, but maybe there's something I can do on the cache object itself to make it better
- Should time traveling change the header boards?
  - Maybe just make the header boards configurable in settings instead? Make up a syntax similar to 4chan X or something, could be cool
- Maybe merge the lists in the boards page into another tabbed card?
- Need to redo boards lists so they can take up more space better