### PR TITLE
Small touch-ups I forgot until now lol

### DIFF
--- a/dapp/src/App.tsx
+++ b/dapp/src/App.tsx
@@ -88,6 +88,8 @@ function App() {
   const [settings, setSettings] = useLocalSettings();
   writeAppSetSettings(setSettings);
 
+  const [pageTheme, setPageTheme] = useState<string>("blueboard");
+
   const client = useMemo(
     () =>
       new ApolloClient({
@@ -115,29 +117,81 @@ function App() {
             <Route path="/0x:id" component={IdReferencePage} />
             <Route
               path="/:board_name/0x:board_id/:view_mode(index|catalog)"
-              component={BoardPage}
+              render={(props) => (
+                <BoardPage
+                  location={props.location}
+                  match={props.match}
+                  pageTheme={pageTheme}
+                  setPageTheme={setPageTheme}
+                />
+              )}
             />
             <Route
               path="/:board_name/0x:board_id/0x:user_id/:thread_n/0x:focus_user_id/:focus_post_n"
-              component={ThreadPage}
+              render={(props) => (
+                <ThreadPage
+                  location={props.location}
+                  match={props.match}
+                  pageTheme={pageTheme}
+                  setPageTheme={setPageTheme}
+                />
+              )}
             />
             <Route
               path="/:board_name/0x:board_id/0x:user_id/:thread_n/0x:focus_user_id"
-              component={ThreadPage}
+              render={(props) => (
+                <ThreadPage
+                  location={props.location}
+                  match={props.match}
+                  pageTheme={pageTheme}
+                  setPageTheme={setPageTheme}
+                />
+              )}
             />
             <Route
               path="/:board_name/0x:board_id/0x:user_id/:thread_n/:focus_post_n"
-              component={ThreadPage}
+              render={(props) => (
+                <ThreadPage
+                  location={props.location}
+                  match={props.match}
+                  pageTheme={pageTheme}
+                  setPageTheme={setPageTheme}
+                />
+              )}
             />
             <Route
               path="/:board_name/0x:board_id/0x:user_id/:thread_n/:post_n"
-              component={ThreadPage}
+              render={(props) => (
+                <ThreadPage
+                  location={props.location}
+                  match={props.match}
+                  pageTheme={pageTheme}
+                  setPageTheme={setPageTheme}
+                />
+              )}
             />
             <Route
               path="/:board_name/0x:board_id/0x:user_id/:thread_n"
-              component={ThreadPage}
+              render={(props) => (
+                <ThreadPage
+                  location={props.location}
+                  match={props.match}
+                  pageTheme={pageTheme}
+                  setPageTheme={setPageTheme}
+                />
+              )}
             />
-            <Route path="/:board_name/0x:board_id" component={BoardPage} />
+            <Route
+              path="/:board_name/0x:board_id" 
+              render={(props) => (
+                <BoardPage
+                  location={props.location}
+                  match={props.match}
+                  pageTheme={pageTheme}
+                  setPageTheme={setPageTheme}
+                />
+              )}
+            />
             <Route exact path="/:board_name" component={BoardsPage} />
           </Switch>
           <FAQCardOverlay />

--- a/dapp/src/assets/styles/atoms.scss
+++ b/dapp/src/assets/styles/atoms.scss
@@ -100,6 +100,18 @@
     border-bottom: 1px solid var(--tertiary-accent);
 }
 
+.border-right-secondary {
+    border-right: 1px solid var(--secondary);
+}
+
+.border-right-secondary-accent {
+    border-right: 1px solid var(--secondary-accent);
+}
+
+.border-right-tertiary {
+    border-right: 1px solid var(--tertiary);
+}
+
 .border-right-tertiary-accent {
     border-right: 1px solid var(--tertiary-accent);
 }

--- a/dapp/src/components/Card.tsx
+++ b/dapp/src/components/Card.tsx
@@ -4,6 +4,7 @@ export default function Card({
   className = "grid",
   bodyClassName = "",
   title,
+  titleRight,
   children,
   open = true,
 }: {
@@ -11,6 +12,7 @@ export default function Card({
   bodyClassName?: string;
   children: ReactElement | ReactElement[];
   title: ReactElement | string;
+  titleRight?: ReactElement;
   open?: boolean;
 }) {
   return (
@@ -18,7 +20,8 @@ export default function Card({
       <details open={open}>
         <summary className="bg-primary border border-black border-b-0 sticky top-0 z-20 text-center">
           <header className="bg-highlight py-1 bg-white border border-l-0 border-r-0 border-solid border-black p-2 z-50">
-            <div className="text-xl text-center font-semibold">{title}</div>
+            <span className="text-xl center font-semibold">{title}</span>
+            {titleRight}
           </header>
         </summary>
         <section

--- a/dapp/src/components/ContentHeader.tsx
+++ b/dapp/src/components/ContentHeader.tsx
@@ -13,6 +13,7 @@ import ContentNavigation from "./ContentNavigation";
 export default function ContentHeader({
   board,
   thread,
+  title,
   search,
   baseUrl,
   block,
@@ -22,6 +23,7 @@ export default function ContentHeader({
 }: {
   board?: Board | null;
   thread?: Thread;
+  title?: string;
   search?: string;
   baseUrl?: string;
   block?: string;
@@ -36,6 +38,7 @@ export default function ContentHeader({
     <div>
       <BoardHeader
         block={block}
+        title={title}
         dateTime={dateTime}
         board={board}
         thread={thread}
@@ -49,9 +52,13 @@ export default function ContentHeader({
        ? <FormPost baseUrl={baseUrl} thread={thread} board={board} />
        : <Loading />}
 
-      <div className="p-2">
-        <hr></hr>
-      </div>
+      {board !== null ?
+        <div className="p-2">
+          <hr></hr>
+        </div>
+      :
+        ""
+      }
 
       <div className="text-center sm:text-left grid xl:grid-cols-3 text-xs">
         <div className="mx-2 flex flex-wrap sm:flex-nowrap justify-center md:justify-start items-center">

--- a/dapp/src/components/ContentNavigation.tsx
+++ b/dapp/src/components/ContentNavigation.tsx
@@ -26,7 +26,7 @@ export default function ContentNavigation({
 
   return (
     <span className="whitespace-nowrap sm:flex">
-      <span className="pr-1">
+      <span>
         <span className="pr-1">
           [
           <Link

--- a/dapp/src/components/PopularBoardsCard.tsx
+++ b/dapp/src/components/PopularBoardsCard.tsx
@@ -1,18 +1,12 @@
 import { Board } from "dchan";
-import { publish } from "pubsub-js";
-import { useCallback } from "react";
 import { Link } from "react-router-dom";
 import BoardTabs from "./BoardTabs";
 
 export default function PopularBoardsCard({block, highlight}: {block?: number, highlight?: Board}) {
-  const onMouseEnter = useCallback(() => {
-    publish("BOARD_ITEM_HOVER_ENTER", undefined)
-  }, [])
-
   return (
     <div className="dchan-popular-boards">
       <BoardTabs block={block} limit={10} highlight={highlight} />
-      <div onMouseEnter={onMouseEnter} className="border border-solid border-black border-t-0 p-2">
+      <div className="border border-solid border-black border-t-0 p-2">
         [
         <Link
           className="dchan-link py-1 px-4"

--- a/dapp/src/components/PopularBoardsCard.tsx
+++ b/dapp/src/components/PopularBoardsCard.tsx
@@ -6,7 +6,7 @@ import BoardTabs from "./BoardTabs";
 
 export default function PopularBoardsCard({block, highlight}: {block?: number, highlight?: Board}) {
   const onMouseEnter = useCallback(() => {
-    publish("BOARD_ALL_HOVER_ENTER")
+    publish("BOARD_ITEM_HOVER_ENTER", undefined)
   }, [])
 
   return (

--- a/dapp/src/components/PostSearchResult.tsx
+++ b/dapp/src/components/PostSearchResult.tsx
@@ -1,11 +1,17 @@
 import { Post } from "dchan";
-import { Link } from "react-router-dom";
+import { useCallback } from "react";
+import { Link, useHistory } from "react-router-dom";
 import BoardLink from "./BoardLink";
 import PostComponent from "./post/Post";
 
 export default function PostSearchResult({ post, block }: { post: Post, block?: string }) {
+  const history = useHistory();
+  const postLink = `/${post.id}${block ? `?block=${block}` : ""}`;
+  const openPost = useCallback(() => {
+    history.push(postLink);
+  }, [history, postLink]);
   return (
-    <div className="my-2" data-theme={post?.board?.isNsfw ? "nsfw" : "blueboard"}>
+    <div className="my-2" data-theme={post?.board?.isNsfw ? "nsfw" : "blueboard"} onDoubleClick={openPost}>
       <PostComponent
         key={post.id}
         post={post}
@@ -21,8 +27,9 @@ export default function PostSearchResult({ post, block }: { post: Post, block?: 
             <span className="p-1 whitespace-nowrap">
               [
               <Link
-                to={`/${post.id}${block ? `?block=${block}` : ""}`}
+                to={postLink}
                 className="dchan-link inline"
+                title="View post in thread"
               >
                 View
               </Link>

--- a/dapp/src/components/board/header.tsx
+++ b/dapp/src/components/board/header.tsx
@@ -10,6 +10,7 @@ import { DateTime } from "luxon";
 
 export default function BoardHeader({
   block,
+  title,
   dateTime,
   board,
   thread,
@@ -17,6 +18,7 @@ export default function BoardHeader({
   search,
 }: {
   block?: string;
+  title?: string;
   dateTime?: DateTime;
   board?: Board | null;
   thread?: Thread;
@@ -57,7 +59,7 @@ export default function BoardHeader({
           </span>{" "}
           <span className="font-semibold">
             {board === null ? (
-              <div>/?/ - ?????</div>
+              <div>{title ? title : "/?/ - ?????"}</div>
             ) : (
               <Link
                 to={

--- a/dapp/src/components/board/list.tsx
+++ b/dapp/src/components/board/list.tsx
@@ -26,7 +26,10 @@ function BoardItem({
   }, [board, publish])
 
   return (
-    <tr className={`relative ${highlight?.id === board.id ? "bg-secondary" : ""}`} key={id} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
+    <tr className={`relative ${highlight?.id === board.id ? "bg-secondary" : ""}`}
+        key={id}
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}>
       <td>
         <IdLabel
           id={id}

--- a/dapp/src/components/board/list.tsx
+++ b/dapp/src/components/board/list.tsx
@@ -2,7 +2,7 @@ import { Link } from "react-router-dom";
 import { Board } from "dchan";
 import { IdLabel, Loading } from "components";
 import { usePubSub } from "hooks";
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 
 function BoardItem({
   board, 
@@ -17,19 +17,27 @@ function BoardItem({
 
   const { publish } = usePubSub();
 
-  const onMouseEnter = useCallback(() => {
-    publish("BOARD_ITEM_HOVER_ENTER", board)
-  }, [board, publish])
+  const [isHovering, setIsHovering] = useState(false);
 
-  const onMouseLeave = useCallback(() => {
-    publish("BOARD_ITEM_HOVER_LEAVE", board)
-  }, [board, publish])
+  const handleMouseOver = () => {
+    setIsHovering(true);
+  };
+
+  const handleMouseOut = () => {
+    setIsHovering(false);
+  };
+
+  const onClick = useCallback(() => {
+    publish("BOARD_ITEM_SELECT", board);
+  }, [board, publish]);
 
   return (
-    <tr className={`relative ${highlight?.id === board.id ? "bg-secondary" : ""}`}
+    <tr className={`relative ${isHovering ? "bg-secondary" : highlight?.id === board.id ? "bg-tertiary" : ""}`}
         key={id}
-        onMouseEnter={onMouseEnter}
-        onMouseLeave={onMouseLeave}>
+        title="Click to view threads on homepage"
+        onMouseOver={handleMouseOver}
+        onMouseOut={handleMouseOut}
+        onClick={onClick}>
       <td>
         <IdLabel
           id={id}

--- a/dapp/src/components/header/HeaderNavigation.tsx
+++ b/dapp/src/components/header/HeaderNavigation.tsx
@@ -33,6 +33,11 @@ const siteCreatedAtBlock: Block = {
   timestamp: "1628450632",
 };
 
+type StartBlock = {
+  label: string,
+  block: Block,
+};
+
 const SettingsWidgetOverlay = OverlayComponent(SettingsWidget);
 
 export default function HeaderNavigation({
@@ -51,7 +56,10 @@ export default function HeaderNavigation({
   search?: string;
 }) {
   const [isOpen, setIsOpen] = useState<boolean>();
-  const [startBlock, setStartBlock] = useState<Block | undefined>();
+  const [startBlock, setStartBlock] = useState<StartBlock>({
+    label: "Site creation",
+    block: siteCreatedAtBlock,
+  });
   const [openedWidget, setOpenedWidget] = useState<OpenedWidgetEnum | null>(
     null
   );
@@ -61,12 +69,20 @@ export default function HeaderNavigation({
   const settingsRef = useRef<HTMLElement>(null);
 
   useEffect(() => {
+    if (!thread && !board) {
+      // persist the current start block until we know it's actually changed
+      // this is to prevent the time travel range jumping around every time
+      // the user time travels
+      return;
+    }
     setStartBlock(
       thread
-        ? thread.createdAtBlock
-        : board
-        ? board.createdAtBlock
-        : siteCreatedAtBlock
+        ? {label: "Thread creation", block: thread.createdAtBlock
+       }
+      : board
+        ? {label: "Board creation", block: board.createdAtBlock
+       }
+      : {label: "Site creation", block: siteCreatedAtBlock}
     );
   }, [thread, board, setStartBlock]);
 
@@ -136,15 +152,9 @@ export default function HeaderNavigation({
                 onClose={() => setOpenedWidget(null)}
                 block={block}
                 baseUrl={baseUrl || ""}
-                startBlock={startBlock}
+                startBlock={startBlock.block}
                 dateTime={dateTime}
-                startRangeLabel={
-                  thread
-                    ? "Thread creation"
-                    : board
-                    ? "Board creation"
-                    : "Site creation"
-                }
+                startRangeLabel={startBlock.label}
               />
             )}
           </ApolloConsumer>

--- a/dapp/src/components/header/HeaderNavigation.tsx
+++ b/dapp/src/components/header/HeaderNavigation.tsx
@@ -50,6 +50,7 @@ export default function HeaderNavigation({
   baseUrl?: string;
   search?: string;
 }) {
+  const [isOpen, setIsOpen] = useState<boolean>();
   const [startBlock, setStartBlock] = useState<Block | undefined>();
   const [openedWidget, setOpenedWidget] = useState<OpenedWidgetEnum | null>(
     null

--- a/dapp/src/components/header/HeaderNavigation.tsx
+++ b/dapp/src/components/header/HeaderNavigation.tsx
@@ -55,7 +55,6 @@ export default function HeaderNavigation({
   baseUrl?: string;
   search?: string;
 }) {
-  const [isOpen, setIsOpen] = useState<boolean>();
   const [startBlock, setStartBlock] = useState<StartBlock>({
     label: "Site creation",
     block: siteCreatedAtBlock,

--- a/dapp/src/components/post/Post.tsx
+++ b/dapp/src/components/post/Post.tsx
@@ -301,7 +301,7 @@ function Post({
                 <div className="y-1">
                   <div
                     className={`h-full max-w-max flex flex-wrap text-left sm:items-start pb-1 ${
-                      isOp ? `max-w-100vw` : "max-w-90vw border-bottom-tertiary-accent"
+                      isOp ? `max-w-100vw` : "max-w-90vw"
                     }`}
                   >
                     <span className="w-full">

--- a/dapp/src/components/post/Post.tsx
+++ b/dapp/src/components/post/Post.tsx
@@ -130,6 +130,26 @@ function Post({
     }
   }, [toggleRef, setShowBody]);
 
+  const bodyClass = [
+    /*
+    isHighlighted || isFocused
+                ? "bg-tertiary"
+                : !isOp
+                ? "bg-secondary border-right-tertiary-accent"
+                : ""
+            } ${
+              isYou ? "dchan-post-you" : ""
+            } w-full sm:w-full mb-2 inline-block relative`
+            */
+    isHighlighted || isFocused
+      ? "bg-tertiary"
+      : !isOp
+      ? "bg-secondary border-bottom-tertiary-accent border-right-tertiary-accent"
+      : "",
+    isYou ? "dchan-post-you" : "",
+    "w-full sm:w-full mb-2 inline-block relative",,
+  ].join(" ");
+
   return (
     <div className="flex relative ">
       {!isOp && showPostMarker ? (
@@ -166,22 +186,12 @@ function Post({
         </div>
         <div
           id={`${n}`}
-          className={`dchan-post text-left w-full  ${
+          className={`dchan-post text-left w-full ${
             !showBody ? "hidden" : ""
           }`}
           dchan-post-from-address={address}
         >
-          <div
-            className={`${
-              isHighlighted || isFocused
-                ? "bg-tertiary"
-                : !isOp
-                ? "bg-secondary border-right-tertiary-accent"
-                : ""
-            } ${
-              isYou ? "dchan-post-you" : ""
-            } w-full sm:w-full mb-2 inline-block relative`}
-          >
+          <div className={bodyClass}>
             <div className="flex sm:flex-wrap ml-5 align-center text-center sm:text-left sm:justify-start max-w-100vw">
               <PostHeader
                 thread={thread}
@@ -301,9 +311,7 @@ function Post({
                 <div className="y-1">
                   <div
                     className={`h-full max-w-max flex flex-wrap text-left sm:items-start pb-1 ${
-                      isOp
-                        ? `max-w-100vw`
-                        : "max-w-90vw border-bottom-tertiary-accent"
+                      isOp ? `max-w-100vw` : "max-w-90vw border-bottom-tertiary-accent"
                     }`}
                   >
                     <span className="w-full">

--- a/dapp/src/components/post/Post.tsx
+++ b/dapp/src/components/post/Post.tsx
@@ -131,23 +131,13 @@ function Post({
   }, [toggleRef, setShowBody]);
 
   const bodyClass = [
-    /*
-    isHighlighted || isFocused
-                ? "bg-tertiary"
-                : !isOp
-                ? "bg-secondary border-right-tertiary-accent"
-                : ""
-            } ${
-              isYou ? "dchan-post-you" : ""
-            } w-full sm:w-full mb-2 inline-block relative`
-            */
     isHighlighted || isFocused
       ? "bg-tertiary"
       : !isOp
       ? "bg-secondary border-bottom-tertiary-accent border-right-tertiary-accent"
       : "",
     isYou ? "dchan-post-you" : "",
-    "w-full sm:w-full mb-2 inline-block relative",,
+    "w-full sm:w-full mb-2 inline-block relative",
   ].join(" ");
 
   return (

--- a/dapp/src/components/post/PostBody.tsx
+++ b/dapp/src/components/post/PostBody.tsx
@@ -256,6 +256,7 @@ function renderValue(
             title={`Youtube video ${val.id}`}
             itemType="text/html"
             src={`//www.youtube.com/embed/${val.id}`}
+            allowFullScreen={true}
             frameBorder="0"
           ></iframe>
         </details>

--- a/dapp/src/components/post/PostHeader.tsx
+++ b/dapp/src/components/post/PostHeader.tsx
@@ -15,8 +15,9 @@ import {
 import { usePubSub, useSettings, useUser, useWeb3, useFavorites } from "hooks";
 import { DateTime } from "luxon";
 import { ReactElement, useCallback, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import { Router } from "router";
+import { parse as parseQueryString } from "query-string";
 
 function DateDisplay({ post }: { post: Post }) {
   const createdAt = fromBigInt(post.createdAtBlock.timestamp);
@@ -37,6 +38,11 @@ function DateDisplay({ post }: { post: Post }) {
     DateTime.TIME_24_WITH_SECONDS
   )}`;
 
+  const location = useLocation();
+  const locationParams = parseQueryString(location.search);
+  locationParams.block = `${post.createdAtBlock.number}`;
+  const timeTravelLink = `${location.pathname}?${new URLSearchParams(locationParams as any).toString()}`;
+
   return (
     <span
       className="px-0.5 whitespace-nowrap text-sm"
@@ -47,7 +53,7 @@ function DateDisplay({ post }: { post: Post }) {
         [
         <Link
           title={`Time travel to ${formattedDate}`}
-          to={`${Router.post(post)}?block=${post.createdAtBlock.number}`}
+          to={timeTravelLink}
         >
           {traveledBlock ? (
             <span>

--- a/dapp/src/dchan/entities/post.ts
+++ b/dapp/src/dchan/entities/post.ts
@@ -3,7 +3,7 @@ import { reverse, sortBy } from "lodash";
 
 export function sortByCreatedAt(posts: Post[] | undefined) {
     return posts && posts.length > 0
-        ? reverse(sortBy(posts, ["createdAtBlock"])) : undefined
+        ? reverse(sortBy(posts, post => parseInt(post.createdAtBlock.timestamp))) : undefined
 }
 export function isLowScore({
     score

--- a/dapp/src/graphql/queries/search_by_ref.ts
+++ b/dapp/src/graphql/queries/search_by_ref.ts
@@ -1,7 +1,7 @@
 import { gql } from "apollo-boost";
 import USER_FRAGMENT from "graphql/fragments/user";
 
-const SEARCH_BY_REF = gql`
+const fragments = gql`
   ${USER_FRAGMENT}
 
   fragment SearchBoard on Board {
@@ -42,7 +42,10 @@ const SEARCH_BY_REF = gql`
       ...SearchPost
     }
   }
+`;
 
+const QUERY_REF = gql`
+  ${fragments}
   query SearchByRef($id: String!, $post_n: BigInt!, $post_ref: String!) {
     threads(where: {board: $id, n: $post_n}) {
       ...SearchThread
@@ -56,4 +59,19 @@ const SEARCH_BY_REF = gql`
   }
 `;
 
-export default SEARCH_BY_REF
+const QUERY_REF_BY_BLOCK = gql`
+  ${fragments}
+  query SearchByRef($id: String!, $post_n: BigInt!, $post_ref: String!, $block: Int!) {
+    threads(where: {board: $id, n: $post_n}, block: {number: $block}) {
+      ...Thread
+    }
+    posts(where: {from: $id, n: $post_n}, block: {number: $block}) {
+      ...Post
+    }
+    postRef(id: $post_ref, block: {number: $block}) {
+      ...PostRef
+    }
+  }
+`;
+
+export default {query_ref: QUERY_REF, query_ref_by_block: QUERY_REF_BY_BLOCK};

--- a/dapp/src/pages/board.tsx
+++ b/dapp/src/pages/board.tsx
@@ -40,7 +40,17 @@ interface BoardVars {
   block: number;
 }
 
-export default function BoardPage({ location, match: { params } }: any) {
+export default function BoardPage({
+  location,
+  match: { params },
+  pageTheme,
+  setPageTheme
+}: {
+  location: any,
+  match: {params: any},
+  pageTheme: string,
+  setPageTheme: (theme: string) => void,
+}) {
   let { board_id, board_name } = params;
   board_id = board_id ? `0x${board_id}` : undefined;
 
@@ -137,10 +147,21 @@ export default function BoardPage({ location, match: { params } }: any) {
       : `Loading... - dchan.network - [${board_id}]`
   );
 
+  useEffect(() => {
+    if (!board) {
+      // persist theme until we know for sure it's different for this board
+      // this is to prevent the theme changing back to default for every
+      // loading screen, e.g. during time travels or when switching between
+      // boards
+      return;
+    }
+    setPageTheme(board?.isNsfw ? "nsfw" : "blueboard");
+  }, [board, setPageTheme]);
+
   return (
     <div
       className="bg-primary min-h-100vh flex flex-col"
-      data-theme={board?.isNsfw ? "nsfw" : "blueboard"}
+      data-theme={pageTheme}
     >
       <div>
         <ContentHeader

--- a/dapp/src/pages/home.tsx
+++ b/dapp/src/pages/home.tsx
@@ -21,6 +21,7 @@ export default function HomePage({ location }: any) {
   useTitle("dchan.network");
 
   const [board, setBoard] = useState<Board>();
+  const [highlight, setHighlight] = useState<Board>();
   const query = parseQueryString(location.search);
   const block = parseInt(`${query.block}`);
   const queriedBlock = isNaN(block) ? undefined : block;
@@ -41,20 +42,22 @@ export default function HomePage({ location }: any) {
     const sub = subscribe(
       "BOARD_ITEM_HOVER_ENTER",
       (_: any, hoverBoard: Board) => {
+        setHighlight(hoverBoard);
         setBoardDebounce(hoverBoard);
       }
     );
 
     return () => unsubscribe(sub);
-  }, [setBoardDebounce]);
+  }, [setHighlight, setBoardDebounce]);
 
   useEffect(() => {
-    const sub = subscribe("BOARD_ALL_HOVER_ENTER", () => {
+    const sub = subscribe("BOARD_ALL_HOVER_LEAVE", () => {
+      setHighlight(undefined);
       setBoardDebounce(undefined);
     });
 
     return () => unsubscribe(sub);
-  }, [setBoardDebounce]);
+  }, [setHighlight, setBoardDebounce]);
 
   return (
     <div className="h-screen bg-primary flex flex-col pb-2">
@@ -71,7 +74,7 @@ export default function HomePage({ location }: any) {
             className="md:px-1 w-full pb-4"
             bodyClassName="p-none b-none"
           >
-            <PopularBoardsCard block={queriedBlock} highlight={board} />
+            <PopularBoardsCard block={queriedBlock} highlight={highlight} />
           </Card>
           <Card
             title={<span>Watched Threads</span>}

--- a/dapp/src/pages/home.tsx
+++ b/dapp/src/pages/home.tsx
@@ -3,7 +3,7 @@ import { WatchedThreadsCard } from "components";
 import HeaderLogo from "components/header/logo";
 import { parse as parseQueryString } from "query-string";
 import { DateTime } from "luxon";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useMemo } from "react";
 import { useTitle } from "react-use";
 import { subscribe, unsubscribe } from "pubsub-js";
 import { Board } from "dchan";
@@ -15,6 +15,7 @@ import {
   ThreadTabs,
   LatestPostsCard,
 } from "components";
+import { debounce } from "lodash";
 
 export default function HomePage({ location }: any) {
   useTitle("dchan.network");
@@ -31,24 +32,29 @@ export default function HomePage({ location }: any) {
     window.scrollTo({ top: 0 });
   }, []);
 
+  const setBoardDebounce = useMemo(
+    () => debounce(setBoard, 500),
+    [setBoard],
+  );
+
   useEffect(() => {
     const sub = subscribe(
       "BOARD_ITEM_HOVER_ENTER",
       (_: any, hoverBoard: Board) => {
-        setBoard(hoverBoard);
+        setBoardDebounce(hoverBoard);
       }
     );
 
     return () => unsubscribe(sub);
-  }, [setBoard]);
+  }, [setBoardDebounce]);
 
   useEffect(() => {
     const sub = subscribe("BOARD_ALL_HOVER_ENTER", () => {
-      setBoard(undefined);
+      setBoardDebounce(undefined);
     });
 
     return () => unsubscribe(sub);
-  }, [setBoard]);
+  }, [setBoardDebounce]);
 
   return (
     <div className="h-screen bg-primary flex flex-col pb-2">

--- a/dapp/src/pages/home.tsx
+++ b/dapp/src/pages/home.tsx
@@ -3,7 +3,7 @@ import { WatchedThreadsCard } from "components";
 import HeaderLogo from "components/header/logo";
 import { parse as parseQueryString } from "query-string";
 import { DateTime } from "luxon";
-import { useEffect, useState, useMemo } from "react";
+import { useEffect, useState, useMemo, useCallback } from "react";
 import { useTitle } from "react-use";
 import { subscribe, unsubscribe } from "pubsub-js";
 import { Board } from "dchan";
@@ -38,23 +38,23 @@ export default function HomePage({ location }: any) {
     [setBoard],
   );
 
+  const clearBoard = useCallback(
+    (e: any) => {
+      e.preventDefault();
+      setHighlight(undefined);
+      setBoard(undefined);
+    },
+    [setHighlight, setBoardDebounce],
+  );
+  
   useEffect(() => {
     const sub = subscribe(
-      "BOARD_ITEM_HOVER_ENTER",
+      "BOARD_ITEM_SELECT",
       (_: any, hoverBoard: Board) => {
         setHighlight(hoverBoard);
-        setBoardDebounce(hoverBoard);
+        setBoard(hoverBoard);
       }
     );
-
-    return () => unsubscribe(sub);
-  }, [setHighlight, setBoardDebounce]);
-
-  useEffect(() => {
-    const sub = subscribe("BOARD_ALL_HOVER_LEAVE", () => {
-      setHighlight(undefined);
-      setBoardDebounce(undefined);
-    });
 
     return () => unsubscribe(sub);
   }, [setHighlight, setBoardDebounce]);
@@ -70,7 +70,16 @@ export default function HomePage({ location }: any) {
       <div className="flex flex-grow flex-col grid-cols-3 xl:grid px-4 text-sm">
         <div>
           <Card
-            title={<span>Boards</span>}
+            title="Boards"
+            titleRight={<>
+              {board != null ?
+                <div className="absolute top-1/2 bottom-1/2 right-0 mr-4">
+                  [<div className="inline dchan-link" onClick={clearBoard}>Clear Board</div>]
+                </div>
+              :
+                ""
+              }
+            </>}
             className="md:px-1 w-full pb-4"
             bodyClassName="p-none b-none"
           >

--- a/dapp/src/pages/idReference.tsx
+++ b/dapp/src/pages/idReference.tsx
@@ -39,7 +39,7 @@ export default function IdReferencePage({ location, match: { params } }: any) {
   const graphQuery = queriedBlock ? SEARCH_BY_ID_BLOCK : SEARCH_BY_ID;
 
   const { data } = useQuery<IdSearchData, IdSearchVars>(graphQuery, {
-    variables: { id, block: queriedBlock ? queriedBlock : undefined },
+    variables: { id, block: queriedBlock },
     pollInterval: 5_000,
   });
 

--- a/dapp/src/pages/postSearch.tsx
+++ b/dapp/src/pages/postSearch.tsx
@@ -76,6 +76,8 @@ export default function PostSearchPage({ location, match: { params } }: any) {
         search={search}
         baseUrl={`${Router.posts()}${search ? `?s=${search}` : ""}`}
         block={queriedBlock}
+        board={null}
+        title="Post Search"
         summary={
           results ? (
             <span>

--- a/dapp/src/pages/reference.tsx
+++ b/dapp/src/pages/reference.tsx
@@ -80,7 +80,7 @@ export default function ReferencePage({ location, match: { params } }: any) {
         history.replace(newLocation);
       }
     }
-  }, [history, data]);
+  }, [history, data, queriedBlock]);
 
   return (
     <div className="bg-primary center grid w-screen h-screen">

--- a/dapp/src/pages/reference.tsx
+++ b/dapp/src/pages/reference.tsx
@@ -1,10 +1,11 @@
 import { useQuery } from "@apollo/react-hooks";
 import { Error, Loading } from "components";
 import { Post, Thread } from "dchan";
-import SEARCH_BY_REF from "graphql/queries/search_by_ref";
+import queries from "graphql/queries/search_by_ref";
 import { useEffect, useState } from "react";
 import { useHistory } from "react-router-dom";
 import { Router } from "router";
+import { parse as parseQueryString } from "query-string";
 
 interface RefSearchData {
   threads: Thread[];
@@ -17,9 +18,10 @@ interface RefSearchVars {
   id: string;
   post_n: string;
   post_ref: string;
+  block?: number;
 }
 
-export default function ReferencePage({ match: { params } }: any) {
+export default function ReferencePage({ location, match: { params } }: any) {
   const [error, setError] = useState<string>();
 
   const history = useHistory();
@@ -27,17 +29,26 @@ export default function ReferencePage({ match: { params } }: any) {
   const id = `0x${params.id}`;
   const post_n = params.post_n;
   const post_ref = `${id}/${post_n}`;
+  const query = parseQueryString(location.search);
+  const block = `${query.block}`;
+  let queriedBlock: number | undefined;
+  if (block) {
+    queriedBlock = parseInt(block);
+    if (isNaN(queriedBlock)) {
+      queriedBlock = undefined;
+    }
+  }
 
   const { loading, data } = useQuery<RefSearchData, RefSearchVars>(
-    SEARCH_BY_REF,
+    queriedBlock ? queries.query_ref_by_block : queries.query_ref,
     {
-      variables: { id, post_n, post_ref },
+      variables: { id, post_n, post_ref, block: queriedBlock },
     }
   );
 
   useEffect(() => {
     if (data) {
-      let location = null;
+      let newLocation = null;
       let thread = null;
       let post = null;
 
@@ -51,20 +62,22 @@ export default function ReferencePage({ match: { params } }: any) {
         post = postRef.post;
       }
 
+      let queriedBlockUrl = queriedBlock ? `?block=${queriedBlock}` : "";
+
       if (thread) {
-        location = `${Router.thread(thread)}`;
+        newLocation = `${Router.thread(thread)}${queriedBlockUrl}`;
       } else if (post) {
-        location = `${Router.post(post)}`;
+        newLocation = `${Router.post(post)}${queriedBlockUrl}`;
       }
 
-      if ((thread || post || postRef) && !location) {
+      if ((thread || post || postRef) && !newLocation) {
         setError(
           "Content not found. It may have been deleted, or the ID is invalid."
         );
       }
 
-      if (location) {
-        history.replace(location);
+      if (newLocation) {
+        history.replace(newLocation);
       }
     }
   }, [history, data]);

--- a/dapp/src/pages/thread.tsx
+++ b/dapp/src/pages/thread.tsx
@@ -22,7 +22,17 @@ interface ThreadContentVars {
   block?: number;
 }
 
-export default function ThreadPage({ location, match: { params } }: any) {
+export default function ThreadPage({
+  location,
+  match: { params },
+  pageTheme,
+  setPageTheme,
+}: {
+  location: any,
+  match: {params: any},
+  pageTheme: string,
+  setPageTheme: (theme: string) => void,
+}) {
   let { board_name, board_id, user_id, thread_n } = params;
   board_id = board_id ? `0x${board_id}` : undefined;
 
@@ -114,6 +124,17 @@ export default function ThreadPage({ location, match: { params } }: any) {
     });
   }, [block, refetch]);
 
+  useEffect(() => {
+    if (!board) {
+      // persist theme until we know for sure it's different for this board
+      // this is to prevent the theme changing back to default for every
+      // loading screen, e.g. during time travels or when switching to the
+      // board view or between threads
+      return;
+    }
+    setPageTheme(board?.isNsfw ? "nsfw" : "blueboard");
+  }, [board, setPageTheme]);
+
   useTitle(
     board && thread
       ? `/${board.name}/ - ${
@@ -123,10 +144,7 @@ export default function ThreadPage({ location, match: { params } }: any) {
   );
 
   return (
-    <div
-      className="bg-primary min-h-100vh flex flex-col"
-      data-theme={board?.isNsfw ? "nsfw" : "blueboard"}
-    >
+    <div className="bg-primary min-h-100vh flex flex-col" data-theme={pageTheme}>
       <ContentHeader
         board={board}
         thread={thread}


### PR DESCRIPTION
- Time travel no longer causes the widget to start from site creation while the time travel is loading
  - No more jumping around every time the slider is moved
- Page theme now persists until the new page has finished loading (currently nsfw boards/threads switch to sfw during each loading pause)
- Double clicking on a post in LatestPostsCard now opens its thread (thought it'd be a nice quality of life thing)
- Selecting a board on the homepage is now a click rather than a hover
  - Preferred it over hovering since it means I don't have to weave my mouse around things to avoid extra queries
  - Also use lodash debounce for that sort of thing or it'll query like mad
- Fixed cross-thread references not obeying time travel
- Allow full-screen for youtube embeds
- Clicking the time travel button on a post now just updates the current page's time travel, rather than linking to the post
  - This lets you click it on the home page/search page and just time travel
- Fix post search sort not actually sorting
- Couple UI fixes